### PR TITLE
order table: add indicator for under capitalized orders

### DIFF
--- a/app/trade/[base]/components/order-details/details-content.tsx
+++ b/app/trade/[base]/components/order-details/details-content.tsx
@@ -107,6 +107,7 @@ export function DetailsContent({ order }: { order: OrderMetadata }) {
         <OrderStatusIndicator order={order} />
         {isOpen && (
           <InsufficientWarning
+            withDialog
             amount={order.data.amount}
             baseMint={order.data.base_mint}
             className="text-sm font-bold tracking-tighter lg:tracking-normal"

--- a/app/trade/[base]/components/order-details/empty-content.tsx
+++ b/app/trade/[base]/components/order-details/empty-content.tsx
@@ -48,6 +48,7 @@ export function EmptyContent({ order }: { order: OrderMetadata }) {
         <OrderStatusIndicator order={order} />
         {isOpen && (
           <InsufficientWarning
+            withDialog
             amount={order.data.amount}
             baseMint={order.data.base_mint}
             className="text-sm font-bold tracking-tighter lg:tracking-normal"

--- a/hooks/use-check-insufficient-balances-for-order.tsx
+++ b/hooks/use-check-insufficient-balances-for-order.tsx
@@ -1,0 +1,52 @@
+import { Token, useBackOfQueueWallet } from "@renegade-fi/react"
+import { formatUnits } from "viem/utils"
+
+import { useUSDPrice } from "@/hooks/use-usd-price"
+import { Side } from "@/lib/constants/protocol"
+
+interface CheckInsufficientBalancesProps {
+  amount: bigint
+  baseMint: `0x${string}`
+  quoteMint: `0x${string}`
+  side: Side
+}
+
+export function useCheckInsufficientBalancesForOrder({
+  amount,
+  baseMint,
+  quoteMint,
+  side,
+}: CheckInsufficientBalancesProps) {
+  const baseToken = Token.findByAddress(baseMint)
+  const quoteToken = Token.findByAddress(quoteMint)
+  const token = side === Side.BUY ? quoteToken : baseToken
+
+  const { data: balance } = useBackOfQueueWallet({
+    query: {
+      select: (data) =>
+        data.balances.find((balance) => balance.mint === token.address)?.amount,
+    },
+  })
+
+  const usdPrice = useUSDPrice(Token.findByAddress(baseMint), amount)
+
+  const isInsufficient = (() => {
+    if (side === Side.BUY) {
+      const formattedUsdPrice = formatUnits(
+        usdPrice,
+        side === Side.BUY ? baseToken.decimals : quoteToken.decimals,
+      )
+      return balance
+        ? parseFloat(formatUnits(balance, token.decimals)) <
+            parseFloat(formattedUsdPrice)
+        : true
+    } else {
+      return balance ? balance < amount : true
+    }
+  })()
+
+  return {
+    isInsufficient,
+    token,
+  }
+}


### PR DESCRIPTION
This PR adds an indicator icon to rows in the order table that is visible if there is not enough balance to fill the order. It also adds a trigger to the warning in the order details sheet to open the transfer dialog with the correct token set for easy depositing.

Tested locally and using a preview deploy.