### PR TITLE
app: add maintenance mode

### DIFF
--- a/app/api/get-maintenance-mode/route.ts
+++ b/app/api/get-maintenance-mode/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server"
+
+import { get } from "@vercel/edge-config"
+
+export async function GET() {
+  const maintenanceMode = await get<MaintenanceMode>("maintenance_mode")
+  return NextResponse.json(maintenanceMode)
+}
+
+export interface MaintenanceMode {
+  enabled: boolean
+  bannerMessage: string
+  severity: "info" | "warning" | "critical"
+  reason: string
+}

--- a/app/components/maintenance-banner.tsx
+++ b/app/components/maintenance-banner.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import React, { useEffect, useState } from "react"
+
+import { AlertCircle, AlertTriangle, Info } from "lucide-react"
+
+import { useMaintenanceMode } from "@/hooks/use-maintenance-mode"
+
+export function MaintenanceBanner() {
+  const { data: maintenanceMode, isLoading } = useMaintenanceMode()
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    if (!isLoading && maintenanceMode?.enabled) {
+      setTimeout(() => setIsVisible(true), 100)
+    } else {
+      setIsVisible(false)
+    }
+  }, [isLoading, maintenanceMode?.enabled])
+
+  const getBgColor = () => {
+    switch (maintenanceMode?.severity) {
+      case "critical":
+        return "bg-[#2A1700]"
+      case "warning":
+        return ""
+      default:
+        return ""
+    }
+  }
+
+  const getTextColor = () => {
+    switch (maintenanceMode?.severity) {
+      case "critical":
+        return "text-orange-500"
+      case "warning":
+        return "text-yellow"
+      default:
+        return "text-blue"
+    }
+  }
+
+  const getIcon = () => {
+    switch (maintenanceMode?.severity) {
+      case "critical":
+        return AlertCircle
+      case "warning":
+        return AlertTriangle
+      default:
+        return Info
+    }
+  }
+
+  const bannerContent = (
+    <div
+      className={`flex w-full items-center border-b border-border ${getBgColor()} px-4 py-2 text-sm ${getTextColor()}`}
+    >
+      {React.createElement(getIcon(), {
+        className: "mr-2 min-h-4 min-w-4 max-h-4 max-w-4",
+      })}
+      <div className="text-pretty">{maintenanceMode?.bannerMessage}</div>
+    </div>
+  )
+
+  return (
+    <div
+      className={`transition-all duration-300 ease-in ${
+        isVisible ? "max-h-20 opacity-100" : "max-h-0 overflow-hidden opacity-0"
+      }`}
+    >
+      {bannerContent}
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import localFont from "next/font/local"
 import { headers } from "next/headers"
-import Script from "next/script"
 import { Viewport } from "next/types"
 
 import { cookieToInitialState as renegadeCookieToInitialState } from "@renegade-fi/react"

--- a/app/orders/data-table.tsx
+++ b/app/orders/data-table.tsx
@@ -21,8 +21,11 @@ import { OrderDetailsSheet } from "@/app/trade/[base]/components/order-details/o
 import { TableEmptyState } from "@/components/table-empty-state"
 import { TableSelect } from "@/components/table-select"
 import { Button } from "@/components/ui/button"
-import { Label } from "@/components/ui/label"
-import { Switch } from "@/components/ui/switch"
+import {
+  ResponsiveTooltip,
+  ResponsiveTooltipContent,
+  ResponsiveTooltipTrigger,
+} from "@/components/ui/responsive-tooltip"
 import {
   Table,
   TableBody,
@@ -39,6 +42,7 @@ import {
 } from "@/components/ui/tooltip"
 
 import { useCancelAllOrders } from "@/hooks/use-cancel-all-orders"
+import { useMaintenanceMode } from "@/hooks/use-maintenance-mode"
 import { ExtendedOrderMetadata } from "@/hooks/use-order-table-data"
 import { DISPLAY_TOKENS } from "@/lib/token"
 import { cn } from "@/lib/utils"
@@ -169,6 +173,8 @@ export function DataTable<TData, TValue>({
     table.getColumn("mint")?.setFilterValue(mint)
   }, [mint, table])
 
+  const { data: maintenanceMode } = useMaintenanceMode()
+
   return (
     <>
       <div className="flex flex-wrap items-center gap-2 lg:gap-4">
@@ -205,15 +211,33 @@ export function DataTable<TData, TValue>({
             Clear
           </Button>
         ) : null}
-        <Button
-          className="text-muted-foreground sm:ml-auto"
-          disabled={isDisabled}
-          size="sm"
-          variant="outline"
-          onClick={handleCancelAllOrders}
-        >
-          Cancel all open orders
-        </Button>
+        <ResponsiveTooltip>
+          <ResponsiveTooltipTrigger className="sm:ml-auto">
+            <Button
+              className="text-muted-foreground"
+              disabled={
+                isDisabled ||
+                (maintenanceMode?.enabled &&
+                  maintenanceMode.severity === "critical")
+              }
+              size="sm"
+              variant="outline"
+              onClick={handleCancelAllOrders}
+            >
+              Cancel all open orders
+            </Button>
+          </ResponsiveTooltipTrigger>
+          <ResponsiveTooltipContent
+            className={
+              maintenanceMode?.enabled &&
+              maintenanceMode.severity === "critical"
+                ? "visible"
+                : "invisible"
+            }
+          >
+            {`Cancelling orders is temporarily disabled${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`}
+          </ResponsiveTooltipContent>
+        </ResponsiveTooltip>
         <Tooltip>
           <TooltipTrigger asChild>
             <Toggle

--- a/app/trade/[base]/components/new-order/new-order-form.tsx
+++ b/app/trade/[base]/components/new-order/new-order-form.tsx
@@ -29,11 +29,17 @@ import {
 } from "@/components/ui/form"
 import { Label } from "@/components/ui/label"
 import {
+  ResponsiveTooltip,
+  ResponsiveTooltipContent,
+  ResponsiveTooltipTrigger,
+} from "@/components/ui/responsive-tooltip"
+import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
+import { useMaintenanceMode } from "@/hooks/use-maintenance-mode"
 import { useOrderValue } from "@/hooks/use-order-value"
 import { usePredictedFees } from "@/hooks/use-predicted-fees"
 import { usePriceQuery } from "@/hooks/use-price-query"
@@ -70,6 +76,7 @@ export function NewOrderForm({
   onSubmit: (values: NewOrderConfirmationProps) => void
 }) {
   const { side, setSide } = useSide()
+  const { data: maintenanceMode } = useMaintenanceMode()
 
   const isMaxOrders = useIsMaxOrders()
   const status = useStatus()
@@ -273,14 +280,33 @@ export function NewOrderForm({
         />
         {status === "in relayer" ? (
           <div>
-            <Button
-              className="flex w-full font-serif text-2xl font-bold tracking-tighter lg:tracking-normal"
-              disabled={!form.formState.isValid || isMaxOrders}
-              size="xl"
-              variant="default"
-            >
-              {form.getValues("isSell") ? "Sell" : "Buy"} {base}
-            </Button>
+            <ResponsiveTooltip>
+              <ResponsiveTooltipTrigger className="!pointer-events-auto w-full">
+                <Button
+                  className="flex w-full font-serif text-2xl font-bold tracking-tighter lg:tracking-normal"
+                  disabled={
+                    !form.formState.isValid ||
+                    isMaxOrders ||
+                    (maintenanceMode?.enabled &&
+                      maintenanceMode.severity === "critical")
+                  }
+                  size="xl"
+                  variant="default"
+                >
+                  {form.getValues("isSell") ? "Sell" : "Buy"} {base}
+                </Button>
+              </ResponsiveTooltipTrigger>
+              <ResponsiveTooltipContent
+                className={
+                  maintenanceMode?.enabled &&
+                  maintenanceMode.severity === "critical"
+                    ? "visible"
+                    : "invisible"
+                }
+              >
+                {`Placing orders is temporarily disabled${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`}
+              </ResponsiveTooltipContent>
+            </ResponsiveTooltip>
           </div>
         ) : (
           <ConnectButton className="flex w-full font-serif text-2xl font-bold tracking-tighter lg:tracking-normal" />

--- a/app/trade/[base]/components/order-details/cancel-button.tsx
+++ b/app/trade/[base]/components/order-details/cancel-button.tsx
@@ -2,7 +2,13 @@ import { UpdateType, useCancelOrder } from "@renegade-fi/react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
+import {
+  ResponsiveTooltip,
+  ResponsiveTooltipContent,
+  ResponsiveTooltipTrigger,
+} from "@/components/ui/responsive-tooltip"
 
+import { useMaintenanceMode } from "@/hooks/use-maintenance-mode"
 import { usePrepareCancelOrder } from "@/hooks/usePrepareCancelOrder"
 import { constructStartToastMessage } from "@/lib/constants/task"
 
@@ -15,30 +21,50 @@ export function CancelButton({
 }) {
   const { request } = usePrepareCancelOrder({ id })
   const { cancelOrder } = useCancelOrder()
+  const { data: maintenanceMode } = useMaintenanceMode()
   return (
-    <Button
-      autoFocus
-      className="flex-1"
-      disabled={isDisabled}
-      variant="outline"
-      onClick={() =>
-        cancelOrder(
-          {
-            id,
-            request,
-          },
-          {
-            onSuccess: (data) => {
-              const message = constructStartToastMessage(UpdateType.CancelOrder)
-              toast.loading(message, {
-                id: data.taskId,
-              })
-            },
-          },
-        )
-      }
-    >
-      Cancel Order
-    </Button>
+    <ResponsiveTooltip>
+      <ResponsiveTooltipTrigger className="!pointer-events-auto w-full">
+        <Button
+          autoFocus
+          className="w-full flex-1"
+          disabled={
+            isDisabled ||
+            (maintenanceMode?.enabled &&
+              maintenanceMode.severity === "critical")
+          }
+          variant="outline"
+          onClick={() =>
+            cancelOrder(
+              {
+                id,
+                request,
+              },
+              {
+                onSuccess: (data) => {
+                  const message = constructStartToastMessage(
+                    UpdateType.CancelOrder,
+                  )
+                  toast.loading(message, {
+                    id: data.taskId,
+                  })
+                },
+              },
+            )
+          }
+        >
+          Cancel Order
+        </Button>
+      </ResponsiveTooltipTrigger>
+      <ResponsiveTooltipContent
+        className={
+          maintenanceMode?.enabled && maintenanceMode.severity === "critical"
+            ? "visible"
+            : "invisible"
+        }
+      >
+        {`Cancelling orders is temporarily disabled${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`}
+      </ResponsiveTooltipContent>
+    </ResponsiveTooltip>
   )
 }

--- a/app/trade/[base]/page-client.tsx
+++ b/app/trade/[base]/page-client.tsx
@@ -3,6 +3,7 @@
 import React from "react"
 
 import { DepositBanner } from "@/app/components/deposit-banner"
+import { MaintenanceBanner } from "@/app/components/maintenance-banner"
 import { MobileBottomBar } from "@/app/components/mobile-bottom-bar"
 import { columns } from "@/app/orders/columns"
 import { DataTable } from "@/app/orders/data-table"
@@ -35,6 +36,7 @@ export function PageClient({
 
   return (
     <div>
+      <MaintenanceBanner />
       <DepositBanner />
       <BBOMarquee base={base} />
       <MobileAssetPriceAccordion base={base} />

--- a/components/dialogs/transfer/transfer-dialog.tsx
+++ b/components/dialogs/transfer/transfer-dialog.tsx
@@ -35,11 +35,17 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form"
+import {
+  ResponsiveTooltip,
+  ResponsiveTooltipContent,
+  ResponsiveTooltipTrigger,
+} from "@/components/ui/responsive-tooltip"
 
 import { useApprove } from "@/hooks/use-approve"
 import { useCheckChain } from "@/hooks/use-check-chain"
 import { useDeposit } from "@/hooks/use-deposit"
 import { useFeeOnZeroBalance } from "@/hooks/use-fee-on-zero-balance"
+import { useMaintenanceMode } from "@/hooks/use-maintenance-mode"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { usePriceQuery } from "@/hooks/use-price-query"
 import { useRefreshOnBlock } from "@/hooks/use-refresh-on-block"
@@ -455,6 +461,8 @@ function TransferForm({
     }
   }
 
+  const { data: maintenanceMode } = useMaintenanceMode()
+
   return (
     <Form {...form}>
       <form
@@ -549,20 +557,40 @@ function TransferForm({
         </div>
         {isDesktop ? (
           <DialogFooter>
-            <Button
-              className="flex-1 border-x-0 border-b-0 border-t font-extended text-2xl"
-              disabled={
-                !form.formState.isValid ||
-                (direction === ExternalTransferDirection.Deposit &&
-                  isMaxBalances) ||
-                approveStatus === "pending" ||
-                depositStatus === "pending"
-              }
-              size="xl"
-              variant="outline"
-            >
-              {buttonText}
-            </Button>
+            <ResponsiveTooltip>
+              <ResponsiveTooltipTrigger
+                asChild
+                className="!pointer-events-auto"
+                type="submit"
+              >
+                <Button
+                  className="flex-1 border-0 border-t font-extended text-2xl"
+                  disabled={
+                    !form.formState.isValid ||
+                    (direction === ExternalTransferDirection.Deposit &&
+                      isMaxBalances) ||
+                    approveStatus === "pending" ||
+                    depositStatus === "pending" ||
+                    (maintenanceMode?.enabled &&
+                      maintenanceMode.severity === "critical")
+                  }
+                  size="xl"
+                  variant="outline"
+                >
+                  {buttonText}
+                </Button>
+              </ResponsiveTooltipTrigger>
+              <ResponsiveTooltipContent
+                className={
+                  maintenanceMode?.enabled &&
+                  maintenanceMode.severity === "critical"
+                    ? "visible"
+                    : "invisible"
+                }
+              >
+                {`Transfers are temporarily disabled${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`}
+              </ResponsiveTooltipContent>
+            </ResponsiveTooltip>
           </DialogFooter>
         ) : (
           <DialogFooter className="mt-auto flex-row">
@@ -575,20 +603,36 @@ function TransferForm({
                 Close
               </Button>
             </DialogClose>
-            <Button
-              className="flex-1 border-l-0 font-extended text-lg"
-              disabled={
-                !form.formState.isValid ||
-                (direction === ExternalTransferDirection.Deposit &&
-                  isMaxBalances) ||
-                approveStatus === "pending" ||
-                depositStatus === "pending"
-              }
-              size="xl"
-              variant="default"
-            >
-              {buttonText}
-            </Button>
+            <ResponsiveTooltip>
+              <ResponsiveTooltipTrigger className="flex-1">
+                <Button
+                  className="w-full border-l-0 font-extended text-lg"
+                  disabled={
+                    !form.formState.isValid ||
+                    (direction === ExternalTransferDirection.Deposit &&
+                      isMaxBalances) ||
+                    approveStatus === "pending" ||
+                    depositStatus === "pending" ||
+                    (maintenanceMode?.enabled &&
+                      maintenanceMode.severity === "critical")
+                  }
+                  size="xl"
+                  variant="outline"
+                >
+                  {buttonText}
+                </Button>
+              </ResponsiveTooltipTrigger>
+              <ResponsiveTooltipContent
+                className={
+                  maintenanceMode?.enabled &&
+                  maintenanceMode.severity === "critical"
+                    ? "visible"
+                    : "invisible"
+                }
+              >
+                {`Transfers are temporarily disabled${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`}
+              </ResponsiveTooltipContent>
+            </ResponsiveTooltip>
           </DialogFooter>
         )}
       </form>

--- a/components/ui/responsive-tooltip.tsx
+++ b/components/ui/responsive-tooltip.tsx
@@ -26,10 +26,10 @@ export function ResponsiveTooltipTrigger({ children, ...props }: ResponsiveToolt
   const isDesktop = useSharedMediaQuery("(min-width: 1024px)");
 
   if (isDesktop) {
-    return <TooltipTrigger {...props}>{children}</TooltipTrigger>;
+    return <TooltipTrigger type="button" {...props}>{children}</TooltipTrigger>;
   }
 
-  return <PopoverTrigger {...props}>{children}</PopoverTrigger>;
+  return <PopoverTrigger type="button" {...props}>{children}</PopoverTrigger>;
 }
 
 export function ResponsiveTooltipContent({ children, side, className, ...props }: ResponsiveTooltipContentProps) {

--- a/hooks/use-maintenance-mode.ts
+++ b/hooks/use-maintenance-mode.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { MaintenanceMode } from "@/app/api/get-maintenance-mode/route"
+
+async function fetchMaintenanceMode(): Promise<MaintenanceMode> {
+  const response = await fetch("/api/get-maintenance-mode")
+  if (!response.ok) {
+    throw new Error("Failed to fetch maintenance mode")
+  }
+  return response.json()
+}
+
+export function useMaintenanceMode() {
+  return useQuery<MaintenanceMode, Error>({
+    queryKey: ["maintenanceMode"],
+    queryFn: fetchMaintenanceMode,
+    staleTime: 0,
+  })
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@tanstack/react-query": "^5.45.1",
     "@tanstack/react-table": "^8.17.3",
     "@vercel/analytics": "^1.3.1",
+    "@vercel/edge-config": "^1.3.0",
     "@vercel/kv": "^2.0.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.3.1
         version: 1.3.1(next@14.2.3(@babel/core@7.24.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@vercel/edge-config':
+        specifier: ^1.3.0
+        version: 1.3.0
       '@vercel/kv':
         specifier: ^2.0.0
         version: 2.0.0
@@ -2724,6 +2727,18 @@ packages:
       next:
         optional: true
       react:
+        optional: true
+
+  '@vercel/edge-config-fs@0.1.0':
+    resolution: {integrity: sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==}
+
+  '@vercel/edge-config@1.3.0':
+    resolution: {integrity: sha512-cOS/3y6X6kej3XcVxEClIWrzRdElunfVuCz6OKkOvD8wApk6jaPn0pFqiFUSfaFngHvhvXAnXkreNEaMWdkFuw==}
+    engines: {node: '>=14.6'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
         optional: true
 
   '@vercel/kv@2.0.0':
@@ -9696,6 +9711,12 @@ snapshots:
     optionalDependencies:
       next: 14.2.3(@babel/core@7.24.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
+
+  '@vercel/edge-config-fs@0.1.0': {}
+
+  '@vercel/edge-config@1.3.0':
+    dependencies:
+      '@vercel/edge-config-fs': 0.1.0
 
   '@vercel/kv@2.0.0':
     dependencies:


### PR DESCRIPTION
This PR adds the ability to put the interface in "maintenance mode" where on-chain actions are disabled when the maintenance flag is on (using environment variables).

Tested locally and in preview deployments.