### PR TITLE
order details: use remaining amount for insufficient balance calculation

### DIFF
--- a/app/orders/columns.tsx
+++ b/app/orders/columns.tsx
@@ -60,8 +60,11 @@ export const columns: ColumnDef<ExtendedOrderMetadata>[] = [
     id: "notification",
     header: () => null,
     cell: function Cell({ row }) {
+      const remainingAmount =
+        row.original.data.amount -
+        row.original.fills.reduce((acc, fill) => acc + fill.amount, BigInt(0))
       const { isInsufficient } = useCheckInsufficientBalancesForOrder({
-        amount: row.original.data.amount,
+        amount: remainingAmount,
         baseMint: row.original.data.base_mint,
         quoteMint: row.original.data.quote_mint,
         side: row.original.data.side === "Buy" ? Side.BUY : Side.SELL,

--- a/app/trade/[base]/components/order-details/details-content.tsx
+++ b/app/trade/[base]/components/order-details/details-content.tsx
@@ -47,6 +47,7 @@ export function DetailsContent({ order }: { order: OrderMetadata }) {
     Number(filledAmount),
     Number(order.data.amount),
   )
+  const remainingAmount = order.data.amount - filledAmount
 
   const formattedTotalAmount = formatNumber(
     order.data.amount,
@@ -108,7 +109,7 @@ export function DetailsContent({ order }: { order: OrderMetadata }) {
         {isOpen && (
           <InsufficientWarning
             withDialog
-            amount={order.data.amount}
+            amount={remainingAmount}
             baseMint={order.data.base_mint}
             className="text-sm font-bold tracking-tighter lg:tracking-normal"
             quoteMint={order.data.quote_mint}


### PR DESCRIPTION
This PR fixes an issue when determining if an order was undercapitalized or not.

Tested locally and in preview deployment.