### PR TITLE
transfer dialog: wrap footer button if needed

### DIFF
--- a/components/dialogs/transfer/transfer-dialog.tsx
+++ b/components/dialogs/transfer/transfer-dialog.tsx
@@ -609,7 +609,7 @@ function TransferForm({
             <ResponsiveTooltip>
               <ResponsiveTooltipTrigger className="flex-1">
                 <Button
-                  className="w-full !border-l-0 font-extended text-lg"
+                  className="w-full whitespace-normal !border-l-0 font-extended text-lg leading-tight"
                   disabled={
                     !form.formState.isValid ||
                     (direction === ExternalTransferDirection.Deposit &&


### PR DESCRIPTION
This PR fixes a text wrap issue in the footer button of the transfer dialog.

Tested locally and in preview deployment.