### PR TITLE
stats: opt out of static rendering

### DIFF
--- a/app/stats/charts/volume-chart.tsx
+++ b/app/stats/charts/volume-chart.tsx
@@ -5,7 +5,6 @@ import * as React from "react"
 import numeral from "numeral"
 import { Bar, BarChart, CartesianGrid, XAxis } from "recharts"
 
-import { useCumulativeVolume } from "@/app/stats/hooks/use-cumulative-volume"
 import { useVolumeData } from "@/app/stats/hooks/use-volume-data"
 
 import {

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,8 +1,11 @@
+import { unstable_noStore } from "next/cache"
+
 import { Footer } from "@/app/components/footer"
 import { Header } from "@/app/components/header"
 import { PageClient } from "@/app/stats/page-client"
 
 export default function Page() {
+  unstable_noStore()
   return (
     <div className="grid min-h-screen grid-cols-1 grid-rows-[auto_1fr_auto_auto]">
       <div className="min-h-20">


### PR DESCRIPTION
This PR opts `/stats` page out of static rendering. According to the Next.js docs: ```If you prefer not to pass additional options to fetch, like cache: 'no-store', next: { revalidate: 0 } or in cases where fetch is not available, you can use noStore() as a replacement for all of these use cases.```