### PR TITLE
stats: unset fetchCache + unstable_noStore

### DIFF
--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,13 +1,8 @@
-import { unstable_noStore } from "next/cache"
-
 import { Footer } from "@/app/components/footer"
 import { Header } from "@/app/components/header"
 import { PageClient } from "@/app/stats/page-client"
 
-export const fetchCache = "force-no-store"
-
 export default function Page() {
-  unstable_noStore()
   return (
     <div className="grid min-h-screen grid-cols-1 grid-rows-[auto_1fr_auto_auto]">
       <div className="min-h-20">


### PR DESCRIPTION
This PR unsets fetchCache and unstable_noStore config options that ultimately do not have any affect on the caching of requests to the KV database. 