### PR TITLE
settings dropdown: hide pwa button if in pwa

### DIFF
--- a/app/trade/[base]/components/settings-dropdown.tsx
+++ b/app/trade/[base]/components/settings-dropdown.tsx
@@ -33,12 +33,15 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
+import { useMediaQuery } from "@/hooks/use-media-query"
 import { STORAGE_REMEMBER_ME } from "@/lib/constants/storage"
+import { cn } from "@/lib/utils"
 
 export function SettingsDropdown({ children }: { children: React.ReactNode }) {
   const config = useConfig()
   const status = useStatus()
   const walletId = useWalletId()
+  const isPWA = useMediaQuery("(display-mode: standalone)")
   const handleRefreshWallet = async () => {
     if (status === "in relayer") {
       await refreshWallet(config)
@@ -74,7 +77,7 @@ export function SettingsDropdown({ children }: { children: React.ReactNode }) {
           <DropdownMenuSeparator />
           <DialogTrigger
             asChild
-            className="lg:hidden"
+            className={cn("lg:hidden", isPWA && "hidden")}
           >
             <DropdownMenuItem>Install Mobile App</DropdownMenuItem>
           </DialogTrigger>


### PR DESCRIPTION
This PR uses media queries to determine if the app is being run in a PWA (in standalone display mode) and hides the "Install Mobile App" button if so.