### PR TITLE
transfer dialog: pay fees and render withdraw toast

### DIFF
--- a/app/components/task-toaster.tsx
+++ b/app/components/task-toaster.tsx
@@ -20,30 +20,8 @@ import {
   isWithdrawTask,
 } from "@/lib/task"
 
-const DURATION_MS = 15_000 // 15 seconds
-
 export function TaskToaster() {
-  const toastTimers = React.useRef<Map<string, NodeJS.Timeout>>(new Map())
   const seenStates = React.useRef<Map<string, string>>(new Map())
-
-  const scheduleToastDismissal = React.useCallback((id: string) => {
-    if (toastTimers.current.has(id)) {
-      clearTimeout(toastTimers.current.get(id)!)
-    }
-    const timer = setTimeout(() => {
-      toast.dismiss(id)
-      toastTimers.current.delete(id)
-      seenStates.current.delete(id)
-    }, DURATION_MS)
-    toastTimers.current.set(id, timer)
-  }, [])
-
-  React.useEffect(() => {
-    const timers = toastTimers.current
-    return () => {
-      timers.forEach(clearTimeout)
-    }
-  }, [])
 
   useTaskHistoryWebSocket({
     onUpdate(task) {
@@ -52,14 +30,14 @@ export function TaskToaster() {
       seenStates.current.set(task.id, currentState)
 
       if (isWithdrawTask(task)) {
-        processWithdrawTask(task, scheduleToastDismissal)
+        processWithdrawTask(task)
       } else if (
         isDepositTask(task) ||
         isPlaceOrderTask(task) ||
         isCancelOrderTask(task) ||
         isRefreshWalletTask(task)
       ) {
-        processTask(task, scheduleToastDismissal)
+        processTask(task)
       }
     },
   })
@@ -67,10 +45,7 @@ export function TaskToaster() {
   return null
 }
 
-function processTask(
-  incomingTask: Task,
-  scheduleToastDismissal: (id: string) => void,
-) {
+function processTask(incomingTask: Task) {
   const state = formatTaskState(incomingTask.state)
   const id = incomingTask.id
 
@@ -101,38 +76,48 @@ function processTask(
       icon: <Loader2 className="h-4 w-4 animate-spin text-black" />,
     })
   }
-
-  scheduleToastDismissal(id)
 }
 
-function processWithdrawTask(
-  incomingTask: Task,
-  scheduleToastDismissal: (id: string) => void,
-) {
+function processWithdrawTask(incomingTask: Task) {
   if (isWithdrawTask(incomingTask)) {
     const state = formatTaskState(incomingTask.state)
     const id = incomingTask.id
 
     if (incomingTask.state === "Completed") {
       const message = generateCompletionToastMessage(incomingTask)
-      toast.success(message, { id, description: state, icon: undefined })
+      toast.success(message, {
+        id,
+        description: state,
+        icon: undefined,
+        duration: 10000,
+      })
     } else if (incomingTask.state === "Failed") {
       const message = generateFailedToastMessage(incomingTask)
-      toast.error(message, { id, icon: undefined })
+      toast.error(message, { id, icon: undefined, duration: 10000 })
     } else if (incomingTask.state === "Updating Validity Proofs") {
       const message = generateCompletionToastMessage(incomingTask)
-      toast.success(message, { id, description: "Completed", icon: undefined })
+      toast.success(message, {
+        id,
+        description: "Completed",
+        icon: undefined,
+        duration: 10000,
+      })
     } else if (incomingTask.state === "Proving") {
-      return
+      const message = generateStartToastMessage(incomingTask)
+      toast.success(message, {
+        id,
+        description: state,
+        icon: <Loader2 className="h-4 w-4 animate-spin text-black" />,
+        duration: 10000,
+      })
     } else {
       const message = generateStartToastMessage(incomingTask)
       toast.success(message, {
         id,
         description: state,
         icon: <Loader2 className="h-4 w-4 animate-spin text-black" />,
+        duration: 10000,
       })
     }
-
-    scheduleToastDismissal(id)
   }
 }


### PR DESCRIPTION
This PR starts a `payFees` task if there are more than 2 balances with fees. Also renders toasts for withdraw tasks in Queued states, and makes sure they last for 10s (longer than the default toast duration).