### PR TITLE
fix: replace insufficient with undercapitalized

### DIFF
--- a/app/trade/[base]/components/order-details/insufficient-warning.tsx
+++ b/app/trade/[base]/components/order-details/insufficient-warning.tsx
@@ -8,9 +8,9 @@ import {
   ResponsiveTooltipTrigger,
 } from "@/components/ui/responsive-tooltip"
 
-import { useCheckInsufficientBalancesForOrder } from "@/hooks/use-check-insufficient-balances-for-order"
+import { useIsOrderUndercapitalized } from "@/hooks/use-is-order-undercapitalized"
 import { Side } from "@/lib/constants/protocol"
-import { INSUFFICIENT_BALANCE_TOOLTIP } from "@/lib/constants/tooltips"
+import { UNDERCAPITALIZED_ORDER_TOOLTIP } from "@/lib/constants/tooltips"
 import { cn } from "@/lib/utils"
 
 export function InsufficientWarning({
@@ -30,14 +30,14 @@ export function InsufficientWarning({
   side: Side
   withDialog?: boolean
 }) {
-  const { isInsufficient, token } = useCheckInsufficientBalancesForOrder({
+  const { isUndercapitalized, token } = useIsOrderUndercapitalized({
     amount,
     baseMint,
     quoteMint,
     side,
   })
 
-  if (!isInsufficient) return null
+  if (!isUndercapitalized) return null
 
   const warningContent = (
     <div className={cn("flex items-center gap-2", className)}>
@@ -66,7 +66,7 @@ export function InsufficientWarning({
         </ResponsiveTooltipTrigger>
         <ResponsiveTooltipContent>
           <p>
-            {INSUFFICIENT_BALANCE_TOOLTIP({
+            {UNDERCAPITALIZED_ORDER_TOOLTIP({
               ticker: token.ticker,
             })}
           </p>

--- a/hooks/use-is-order-undercapitalized.tsx
+++ b/hooks/use-is-order-undercapitalized.tsx
@@ -4,19 +4,17 @@ import { formatUnits } from "viem/utils"
 import { useUSDPrice } from "@/hooks/use-usd-price"
 import { Side } from "@/lib/constants/protocol"
 
-interface CheckInsufficientBalancesProps {
-  amount: bigint
-  baseMint: `0x${string}`
-  quoteMint: `0x${string}`
-  side: Side
-}
-
-export function useCheckInsufficientBalancesForOrder({
+export function useIsOrderUndercapitalized({
   amount,
   baseMint,
   quoteMint,
   side,
-}: CheckInsufficientBalancesProps) {
+}: {
+  amount: bigint
+  baseMint: `0x${string}`
+  quoteMint: `0x${string}`
+  side: Side
+}) {
   const baseToken = Token.findByAddress(baseMint)
   const quoteToken = Token.findByAddress(quoteMint)
   const token = side === Side.BUY ? quoteToken : baseToken
@@ -30,7 +28,7 @@ export function useCheckInsufficientBalancesForOrder({
 
   const usdPrice = useUSDPrice(Token.findByAddress(baseMint), amount)
 
-  const isInsufficient = (() => {
+  const isUndercapitalized = (() => {
     if (side === Side.BUY) {
       const formattedUsdPrice = formatUnits(
         usdPrice,
@@ -46,7 +44,7 @@ export function useCheckInsufficientBalancesForOrder({
   })()
 
   return {
-    isInsufficient,
+    isUndercapitalized,
     token,
   }
 }

--- a/lib/constants/tooltips.ts
+++ b/lib/constants/tooltips.ts
@@ -6,7 +6,11 @@ export const FEES_SECTION_BINANCE_FEES =
   "The estimated fees you would pay if you were to execute this order on Binance."
 export const FEES_SECTION_TOTAL_SAVINGS =
   "The amount you save by executing this order on Renegade."
-export const INSUFFICIENT_BALANCE_TOOLTIP = ({ ticker }: { ticker: string }) =>
+export const UNDERCAPITALIZED_ORDER_TOOLTIP = ({
+  ticker,
+}: {
+  ticker: string
+}) =>
   `You do not have enough ${ticker} in your wallet to fully execute this order. Only part of the order will be filled.`
 export const MAX_BALANCES_TOOLTIP = `Renegade wallets can hold a maximum of ${MAX_BALANCES} assets at a time.`
 export const MAX_ORDERS_TOOLTIP = `Renegade wallets can hold a maximum of ${MAX_ORDERS} orders at a time.`


### PR DESCRIPTION
This PR standardizes order undercapitalized checks using the hook. The term 'insufficient' was replaced with 'undercapitalized' for more clarity.