### PR TITLE
order form: add external match option

### DIFF
--- a/app/trade/[base]/components/new-order/fees-sections.tsx
+++ b/app/trade/[base]/components/new-order/fees-sections.tsx
@@ -37,7 +37,7 @@ export function FeesSection({
           <TooltipTrigger asChild>
             <Button
               asChild
-              className="h-5 cursor-pointer p-0 text-sm text-muted-foreground"
+              className="h-5 cursor-pointer p-0 text-muted-foreground"
               type="button"
               variant="link"
             >
@@ -61,7 +61,7 @@ export function FeesSection({
           <TooltipTrigger>
             <Button
               asChild
-              className="h-5 cursor-pointer p-0 text-sm text-muted-foreground"
+              className="h-5 cursor-pointer p-0 text-muted-foreground"
               type="button"
               variant="link"
             >

--- a/components/dialogs/order-stepper/desktop/new-order-stepper.tsx
+++ b/components/dialogs/order-stepper/desktop/new-order-stepper.tsx
@@ -1,19 +1,13 @@
 import * as React from "react"
 
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden"
-
 import { NewOrderFormProps } from "@/app/trade/[base]/components/new-order/new-order-form"
 
 import { DefaultStep } from "@/components/dialogs/order-stepper/desktop/steps/default"
 import { SuccessStepWithoutSavings } from "@/components/dialogs/order-stepper/desktop/steps/success-without-savings"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog"
+import { IOISection } from "@/components/dialogs/order-stepper/ioi-section"
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
+
+import { cn } from "@/lib/utils"
 
 export interface NewOrderConfirmationProps extends NewOrderFormProps {
   onSuccess?: () => void
@@ -27,20 +21,50 @@ export function NewOrderStepperInner({
   ...props
 }: React.PropsWithChildren<NewOrderConfirmationProps>) {
   const { step, open, setOpen } = useStepper()
+  const [allowExternalMatches, setAllowExternalMatches] = React.useState(false)
   return (
     <Dialog
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={(open) => {
+        setAllowExternalMatches(false)
+        setOpen(open)
+      }}
     >
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent
-        className="gap-0 p-0 sm:max-w-[425px]"
+        className="max-w-none border-none bg-transparent p-0 sm:max-w-[425px]"
         onOpenAutoFocus={(e) => {
           e.preventDefault()
         }}
       >
-        {step === Step.DEFAULT && <DefaultStep {...props} />}
-        {step === Step.SUCCESS && <SuccessStepWithoutSavings />}
+        <div className="flex gap-4">
+          <div className="min-w-[425px] flex-1 border bg-background">
+            {step === Step.DEFAULT && (
+              <DefaultStep
+                {...props}
+                allowExternalMatches={allowExternalMatches}
+                setAllowExternalMatches={setAllowExternalMatches}
+              />
+            )}
+            {step === Step.SUCCESS && <SuccessStepWithoutSavings />}
+          </div>
+          <div
+            className={cn(
+              "relative hidden max-h-fit whitespace-nowrap border bg-background lg:block",
+              {
+                hidden: step !== Step.DEFAULT,
+              },
+            )}
+          >
+            <div className="space-y-6 p-6">
+              <IOISection
+                {...props}
+                allowExternalMatches={allowExternalMatches}
+                setAllowExternalMatches={setAllowExternalMatches}
+              />
+            </div>
+          </div>
+        </div>
       </DialogContent>
     </Dialog>
   )

--- a/components/dialogs/order-stepper/desktop/steps/default.tsx
+++ b/components/dialogs/order-stepper/desktop/steps/default.tsx
@@ -14,6 +14,7 @@ import {
   NewOrderConfirmationProps,
   useStepper,
 } from "@/components/dialogs/order-stepper/desktop/new-order-stepper"
+import { IOISection } from "@/components/dialogs/order-stepper/ioi-section"
 import { TokenIcon } from "@/components/token-icon"
 import { Button } from "@/components/ui/button"
 import {
@@ -39,7 +40,12 @@ import { GAS_FEE_TOOLTIP } from "@/lib/constants/tooltips"
 import { formatNumber, safeParseUnits } from "@/lib/format"
 import { decimalCorrectPrice } from "@/lib/utils"
 
-export function DefaultStep(props: NewOrderConfirmationProps) {
+export function DefaultStep(
+  props: NewOrderConfirmationProps & {
+    allowExternalMatches: boolean
+    setAllowExternalMatches: (allowExternalMatches: boolean) => void
+  },
+) {
   const { onNext, setTaskId } = useStepper()
 
   const baseToken = Token.findByTicker(props.base)
@@ -58,6 +64,7 @@ export function DefaultStep(props: NewOrderConfirmationProps) {
     side: props.isSell ? "sell" : "buy",
     amount: props.amount,
     worstCasePrice: worstCasePrice.toFixed(18),
+    allowExternalMatches: props.allowExternalMatches,
   })
 
   const { createOrder } = useCreateOrder({
@@ -89,6 +96,13 @@ export function DefaultStep(props: NewOrderConfirmationProps) {
       <ScrollArea className="max-h-[70vh]">
         <div className="space-y-6 p-6">
           <ConfirmOrderDisplay {...props} />
+          <div className="space-y-6 border p-6 lg:hidden">
+            <IOISection
+              {...props}
+              allowExternalMatches={props.allowExternalMatches}
+              setAllowExternalMatches={props.setAllowExternalMatches}
+            />
+          </div>
         </div>
       </ScrollArea>
       <DialogFooter>
@@ -167,10 +181,12 @@ export function ConfirmOrderDisplay({
             <ResponsiveTooltipTrigger
               onClick={(e) => isDesktop && e.preventDefault()}
             >
-              <span className="text-muted-foreground">Network costs</span>
+              <span className="text-sm text-muted-foreground">
+                Network costs
+              </span>
             </ResponsiveTooltipTrigger>
             <ResponsiveTooltipContent>
-              <p>{GAS_FEE_TOOLTIP}</p>
+              {GAS_FEE_TOOLTIP}
             </ResponsiveTooltipContent>
           </ResponsiveTooltip>
           <div>$0.00</div>

--- a/components/dialogs/order-stepper/ioi-section.tsx
+++ b/components/dialogs/order-stepper/ioi-section.tsx
@@ -1,0 +1,67 @@
+import { Info } from "lucide-react"
+
+import { NewOrderConfirmationProps } from "@/components/dialogs/order-stepper/desktop/new-order-stepper"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+
+import { HELP_CENTER_ARTICLES } from "@/lib/constants/articles"
+
+export function IOISection(
+  props: NewOrderConfirmationProps & {
+    allowExternalMatches: boolean
+    setAllowExternalMatches: (allowExternalMatches: boolean) => void
+  },
+) {
+  return (
+    <>
+      <div className="flex items-start justify-between">
+        <div className="space-y-1.5">
+          <div className="font-extended text-lg font-semibold leading-none tracking-tight">
+            Indications of Interest
+          </div>
+          <div className="text-sm text-muted-foreground">
+            Broadcast intents to the network
+          </div>
+        </div>
+        <a
+          href={HELP_CENTER_ARTICLES.INDICATIONS_OF_INTEREST.url}
+          rel="noreferrer"
+          target="_blank"
+        >
+          <Info className="size-4 text-muted-foreground transition-colors hover:text-foreground" />
+        </a>
+      </div>
+      <div className="items-top flex">
+        <Checkbox
+          checked={props.allowExternalMatches}
+          id="allow-external-matches"
+          onCheckedChange={(checked) => {
+            if (typeof checked === "boolean") {
+              props.setAllowExternalMatches(checked)
+            }
+          }}
+        />
+        <div className="space-y-1 leading-none">
+          <Label
+            className="pl-2 peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            htmlFor="allow-external-matches"
+          >
+            External Matches
+          </Label>
+          <div className="pl-2 text-[0.8rem] text-muted-foreground">
+            Allow third-party solvers to settle matches
+          </div>
+        </div>
+      </div>
+      {props.allowExternalMatches ? (
+        <div className="space-y-4">
+          <Separator />
+          <div className="text-sm text-muted-foreground">
+            Revealing: Pair, Side, Size
+          </div>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/components/dialogs/order-stepper/mobile/steps/confirm.tsx
+++ b/components/dialogs/order-stepper/mobile/steps/confirm.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner"
 
 import { NewOrderConfirmationProps } from "@/components/dialogs/order-stepper/desktop/new-order-stepper"
 import { ConfirmOrderDisplay } from "@/components/dialogs/order-stepper/desktop/steps/default"
+import { IOISection } from "@/components/dialogs/order-stepper/ioi-section"
 import { useStepper } from "@/components/dialogs/order-stepper/mobile/new-order-stepper"
 import { Button } from "@/components/ui/button"
 import {
@@ -14,7 +15,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { usePrepareCreateOrder } from "@/hooks/use-prepare-create-order"
 import { usePriceQuery } from "@/hooks/use-price-query"
@@ -22,6 +22,7 @@ import { constructStartToastMessage } from "@/lib/constants/task"
 import { decimalCorrectPrice } from "@/lib/utils"
 
 export function ConfirmStep(props: NewOrderConfirmationProps) {
+  const [allowExternalMatches, setAllowExternalMatches] = React.useState(false)
   const { onNext, setTaskId } = useStepper()
 
   const baseToken = Token.findByTicker(props.base)
@@ -40,6 +41,7 @@ export function ConfirmStep(props: NewOrderConfirmationProps) {
     side: props.isSell ? "sell" : "buy",
     amount: props.amount,
     worstCasePrice: worstCasePrice.toFixed(18),
+    allowExternalMatches,
   })
 
   const { createOrder } = useCreateOrder({
@@ -59,11 +61,18 @@ export function ConfirmStep(props: NewOrderConfirmationProps) {
 
   return (
     <>
-      <DialogHeader className="p-6 text-left">
+      <DialogHeader className="px-6 pt-6 text-left">
         <DialogTitle className="font-extended">Review Order</DialogTitle>
       </DialogHeader>
-      <div className="space-y-6 overflow-y-auto px-6">
+      <div className="flex flex-col gap-6 overflow-y-auto p-6">
         <ConfirmOrderDisplay {...props} />
+        <div className="space-y-6 border p-6">
+          <IOISection
+            {...props}
+            allowExternalMatches={allowExternalMatches}
+            setAllowExternalMatches={setAllowExternalMatches}
+          />
+        </div>
       </div>
       <DialogFooter className="mt-auto flex-row p-6 pt-0">
         <DialogClose asChild>

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,10 +1,10 @@
-'use client'
+"use client"
 
-import * as React from 'react'
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "@radix-ui/react-icons"
 
-import { cn } from '@/lib/utils'
-import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
-import { CheckIcon } from '@radix-ui/react-icons'
+import { cn } from "@/lib/utils"
 
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
@@ -13,13 +13,13 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
-      className,
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
     )}
     {...props}
   >
     <CheckboxPrimitive.Indicator
-      className={cn('flex items-center justify-center text-current')}
+      className={cn("flex items-center justify-center text-current")}
     >
       <CheckIcon className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>

--- a/hooks/use-prepare-create-order.ts
+++ b/hooks/use-prepare-create-order.ts
@@ -20,6 +20,7 @@ export type UsePrepareCreateOrderParameters = {
   side: "buy" | "sell"
   amount: string
   worstCasePrice: string
+  allowExternalMatches?: boolean
 }
 
 export type UsePrepareCreateOrderReturnType = {
@@ -29,7 +30,15 @@ export type UsePrepareCreateOrderReturnType = {
 export function usePrepareCreateOrder(
   parameters: UsePrepareCreateOrderParameters,
 ) {
-  const { id = "", base, quote, side, amount, worstCasePrice } = parameters
+  const {
+    id = "",
+    base,
+    quote,
+    side,
+    amount,
+    worstCasePrice,
+    allowExternalMatches = false,
+  } = parameters
   const config = useConfig()
   const { data: wallet, isSuccess } = useBackOfQueueWallet()
   const request = React.useMemo(() => {
@@ -54,6 +63,7 @@ export function usePrepareCreateOrder(
       toHex(parsedAmount),
       worstCasePrice,
       toHex(BigInt(0)),
+      allowExternalMatches,
     ) as string
   }, [
     config.state.seed,
@@ -66,6 +76,7 @@ export function usePrepareCreateOrder(
     quote,
     side,
     worstCasePrice,
+    allowExternalMatches,
   ])
   return { request }
 }

--- a/lib/constants/articles.ts
+++ b/lib/constants/articles.ts
@@ -1,0 +1,11 @@
+export const HELP_CENTER_BASE_URL = "https://help.renegade.fi/hc/en-us/articles"
+
+export const HELP_CENTER_ARTICLES = {
+  INDICATIONS_OF_INTEREST: {
+    title: "What are Indications of Interest",
+    url: `${HELP_CENTER_BASE_URL}/35359659794579-What-are-Indications-of-Interest`,
+  },
+} as const
+
+// Type for article keys
+export type HelpCenterArticle = keyof typeof HELP_CENTER_ARTICLES


### PR DESCRIPTION
### Purpose

This PR adds sections to the order placement flow where users can opt-in to enabling external matching on an order.

### Todo

- [x] add link to Help Center articles for explaining Indications of Interest and external matching

### Testing

Tested locally and in preview deployment, made sure orders are placed with `allow_external_matches` set to `true`.