### PR TITLE
route: prevent cache storage on get logs fetch

### DIFF
--- a/app/api/get-logs/route.ts
+++ b/app/api/get-logs/route.ts
@@ -1,15 +1,8 @@
 import { NextRequest } from "next/server"
 
-import { createPublicClient, http, parseAbiItem } from "viem"
-
-import { chain } from "@/lib/viem"
+import { encodeEventTopics, numberToHex, parseAbiItem, toHex } from "viem"
 
 export const runtime = "edge"
-
-// Necessary because public RPC does not support getting logs
-const viemClient = createPublicClient({
-  transport: http(process.env.RPC_URL),
-})
 
 export async function GET(req: NextRequest) {
   try {
@@ -19,17 +12,47 @@ export async function GET(req: NextRequest) {
     if (!blinderShare) {
       throw new Error("Blinder share is required")
     }
-    const logs = await viemClient.getLogs({
-      address: process.env.NEXT_PUBLIC_DARKPOOL_CONTRACT,
-      event: parseAbiItem(
-        "event WalletUpdated(uint256 indexed wallet_blinder_share)",
-      ),
+
+    const topics = encodeEventTopics({
+      abi: [
+        parseAbiItem(
+          "event WalletUpdated(uint256 indexed wallet_blinder_share)",
+        ),
+      ],
       args: {
         wallet_blinder_share: blinderShare,
       },
-      fromBlock: BigInt(process.env.FROM_BLOCK || 0),
     })
-    return new Response(JSON.stringify({ logs: logs.length }))
+
+    // Make raw JSON-RPC call
+    const response = await fetch(process.env.RPC_URL!, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "eth_getLogs",
+        params: [
+          {
+            address: process.env.NEXT_PUBLIC_DARKPOOL_CONTRACT,
+            topics,
+            fromBlock: toHex(process.env.FROM_BLOCK ?? 0),
+          },
+        ],
+      }),
+      cache: "no-store",
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch logs because ${response.statusText}`)
+    }
+
+    const result = await response.json()
+    if (result.error) {
+      throw new Error(`RPC error: ${result.error.message}`)
+    }
+
+    return new Response(JSON.stringify({ logs: result.result.length }))
   } catch (error) {
     console.error(error)
     return new Response(JSON.stringify({ error }), { status: 500 })


### PR DESCRIPTION
This PR constructs a raw request to the RPC node to fetch logs to prevent caching.