### PR TITLE
chore: remove cache related directives

### DIFF
--- a/app/api/amberdata/price/route.ts
+++ b/app/api/amberdata/price/route.ts
@@ -1,7 +1,6 @@
 import { fetchAssetPrice } from "@/app/api/amberdata/helpers"
 
 export const runtime = "edge"
-export const dynamic = "force-dynamic"
 
 export async function GET(request: Request) {
   try {

--- a/app/api/amberdata/route.ts
+++ b/app/api/amberdata/route.ts
@@ -3,8 +3,6 @@ import { NextRequest, NextResponse } from "next/server"
 const AMBERDATA_BASE_URL = "https://api.amberdata.com"
 const API_KEY_HEADER = "x-api-key"
 
-export const dynamic = "force-dynamic"
-
 export async function GET(request: NextRequest) {
   try {
     // Get the path and search params from the request

--- a/app/api/amberdata/token-prices/route.ts
+++ b/app/api/amberdata/token-prices/route.ts
@@ -5,7 +5,6 @@ import { fetchAssetPrice } from "@/app/api/amberdata/helpers"
 import { DISPLAY_TOKENS, remapToken } from "@/lib/token"
 
 export const runtime = "edge"
-export const dynamic = "force-dynamic"
 
 export async function GET(req: NextRequest) {
   const tokens = DISPLAY_TOKENS()

--- a/app/api/get-logs/route.ts
+++ b/app/api/get-logs/route.ts
@@ -40,7 +40,6 @@ export async function GET(req: NextRequest) {
           },
         ],
       }),
-      cache: "no-store",
     })
 
     if (!response.ok) {

--- a/app/api/savings/helpers.ts
+++ b/app/api/savings/helpers.ts
@@ -207,7 +207,7 @@ async function fetchBinanceOrderbookSnapshot(
     endDate,
   )
 
-  const res = await fetch(req, { cache: "no-store" })
+  const res = await fetch(req)
   const orderbookRes: AmberdataOrderbookSnapshotResponse = await res.json()
 
   // The Amberdata response contains snapshots in ascending order of timestamp,
@@ -231,7 +231,7 @@ async function fetchBinanceOrderbookUpdates(
     desiredTimestamp,
   )
 
-  const res = await fetch(req, { cache: "no-store" })
+  const res = await fetch(req)
   const updatesRes: AmberdataOrderbookUpdateResponse = await res.json()
   return updatesRes.payload.data
 }

--- a/app/api/stats/external-transfer-logs/route.ts
+++ b/app/api/stats/external-transfer-logs/route.ts
@@ -9,7 +9,6 @@ import {
 import { getAllSetMembers } from "@/app/lib/kv-utils"
 
 export const runtime = "edge"
-export const dynamic = "force-dynamic"
 
 function startOfPeriod(timestamp: number, intervalMs: number): number {
   return Math.floor(timestamp / intervalMs) * intervalMs
@@ -36,7 +35,6 @@ export async function GET(req: NextRequest) {
           Authorization: `Bearer ${process.env.KV_REST_API_TOKEN}`,
         },
         body: pipelineBody,
-        cache: "no-store",
       },
     )
 

--- a/app/api/stats/historical-volume-kv/route.ts
+++ b/app/api/stats/historical-volume-kv/route.ts
@@ -16,7 +16,6 @@ export interface HistoricalVolumeResponse {
 }
 
 export const runtime = "edge"
-export const dynamic = "force-dynamic"
 
 export async function GET(req: NextRequest) {
   try {
@@ -33,7 +32,6 @@ export async function GET(req: NextRequest) {
           Authorization: `Bearer ${process.env.KV_REST_API_TOKEN}`,
         },
         body: pipelineBody,
-        cache: "no-store",
       },
     )
 

--- a/app/api/stats/net-flow/route.ts
+++ b/app/api/stats/net-flow/route.ts
@@ -6,7 +6,6 @@ export interface NetFlowResponse {
 }
 
 export const runtime = "edge"
-export const dynamic = "force-dynamic"
 
 export async function GET() {
   try {
@@ -17,7 +16,6 @@ export async function GET() {
         headers: {
           Authorization: `Bearer ${process.env.KV_REST_API_TOKEN}`,
         },
-        cache: "no-store",
       },
     )
 

--- a/app/api/stats/set-historical-volume-kv/route.ts
+++ b/app/api/stats/set-historical-volume-kv/route.ts
@@ -26,7 +26,6 @@ const DEFAULT_PARAMS: SearchParams = {
 }
 
 export const maxDuration = 300
-export const dynamic = "force-dynamic"
 
 export async function GET(req: NextRequest) {
   console.log("Starting cron job: set-volume-kv")

--- a/app/api/stats/set-inflow-kv/route.ts
+++ b/app/api/stats/set-inflow-kv/route.ts
@@ -29,7 +29,6 @@ const viemClient = createPublicClient({
 })
 
 export const maxDuration = 300
-export const dynamic = "force-dynamic"
 
 async function getBlockTimestamps(
   blockNumbers: bigint[],

--- a/app/api/stats/set-net-flow-kv/route.ts
+++ b/app/api/stats/set-net-flow-kv/route.ts
@@ -11,7 +11,6 @@ import { getAllSetMembers } from "@/app/lib/kv-utils"
 const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000 // 24 hours in milliseconds
 
 export const maxDuration = 300
-export const dynamic = "force-dynamic"
 
 export async function GET() {
   console.log("Starting net flow calculation cron job")
@@ -38,7 +37,6 @@ export async function GET() {
           Authorization: `Bearer ${process.env.KV_REST_API_TOKEN}`,
         },
         body: pipelineBody,
-        cache: "no-store",
       },
     )
 

--- a/app/api/stats/tvl/route.ts
+++ b/app/api/stats/tvl/route.ts
@@ -3,7 +3,6 @@ import { encodeFunctionData, hexToBigInt, parseAbi } from "viem"
 import { DISPLAY_TOKENS } from "@/lib/token"
 
 export const runtime = "edge"
-export const dynamic = "force-dynamic"
 
 export async function GET() {
   try {
@@ -68,7 +67,6 @@ async function fetchTvl(
       method: "eth_call",
       params: [{ to: tokenAddress, data }, "latest"],
     }),
-    cache: "no-store",
   })
 
   if (!response.ok) {

--- a/app/api/utils.ts
+++ b/app/api/utils.ts
@@ -26,7 +26,6 @@ export async function readErc20BalanceOf(
         method: "eth_call",
         params: [{ to: mint, data }, "latest"],
       }),
-      cache: "no-store",
     })
 
     const result = await response.json()

--- a/app/lib/kv-utils.ts
+++ b/app/lib/kv-utils.ts
@@ -6,7 +6,6 @@ export async function getAllSetMembers(key: string): Promise<string[]> {
       headers: {
         Authorization: `Bearer ${process.env.KV_REST_API_TOKEN}`,
       },
-      cache: "no-store",
     },
   )
 

--- a/app/stats/hooks/use-cumulative-volume.ts
+++ b/app/stats/hooks/use-cumulative-volume.ts
@@ -52,9 +52,7 @@ export async function getCumulativeVolume({ from, to }: VolumeParams) {
   if (to) searchParams.append("to", to.toString())
 
   const url = `/api/stats/cumulative-volume?${searchParams.toString()}`
-  const res = await fetch(url, { cache: "force-cache" }).then((res) =>
-    res.json(),
-  )
+  const res = await fetch(url).then((res) => res.json())
   if (res.error) {
     throw new Error(res.error)
   }

--- a/app/stats/hooks/use-token-prices.ts
+++ b/app/stats/hooks/use-token-prices.ts
@@ -19,9 +19,7 @@ export function useTokenPrices() {
 const fetchTokenPrices = async (): Promise<
   { ticker: string; price: number }[]
 > => {
-  const response = await fetch("/api/amberdata/token-prices", {
-    cache: "no-cache",
-  })
+  const response = await fetch("/api/amberdata/token-prices")
   if (!response.ok) {
     throw new Error("Failed to fetch token prices")
   }

--- a/app/stats/hooks/use-volume-data.ts
+++ b/app/stats/hooks/use-volume-data.ts
@@ -26,9 +26,7 @@ export function useVolumeData(): UseHistoricalVolumeResult {
 }
 
 export async function getHistoricalVolume(): Promise<VolumeDataPoint[]> {
-  const res = await fetch("/api/stats/historical-volume-kv", {
-    cache: "no-store",
-  })
+  const res = await fetch("/api/stats/historical-volume-kv")
 
   if (!res.ok) {
     throw new Error(`Failed to fetch historical volume data: ${res.statusText}`)

--- a/hooks/use-combined-balances.ts
+++ b/hooks/use-combined-balances.ts
@@ -16,9 +16,6 @@ async function fetchCombinedBalances(
 
   const response = await fetch(
     `/api/tokens/get-combined-balances?${params.toString()}`,
-    {
-      cache: "no-store",
-    },
   )
   if (!response.ok) {
     throw new Error("Failed to fetch combined balances")

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     ],
     "paths": {
       "@/*": ["./*"]
-    }
+    },
+    "target": "ES2017"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
This PR removes cache related options (fetch API and Next serverless functions) because in Next.js 15 fetch requests are no longer cached by default (neither are GET requests).