### PR TITLE
order form: prevent flash of insufficient balances to place order

### DIFF
--- a/app/trade/[base]/components/new-order/deposit-warning.tsx
+++ b/app/trade/[base]/components/new-order/deposit-warning.tsx
@@ -34,23 +34,23 @@ export function DepositWarning({
       },
     },
   })
-  if (hasBalances || status !== "in relayer") return null
-
-  return (
-    <div className="flex w-full items-center justify-center rounded-md bg-[#2A1700] p-3 text-center">
-      <ResponsiveTooltip>
-        <ResponsiveTooltipTrigger
-          onClick={(e) => isDesktop && e.preventDefault()}
-        >
-          <div className={cn("flex items-center gap-2", className)}>
-            <AlertTriangle className="h-4 w-4" />
-            <span>Insufficient funds to place orders</span>
-          </div>
-        </ResponsiveTooltipTrigger>
-        <ResponsiveTooltipContent>
-          <p>{ORDER_FORM_DEPOSIT_WARNING({ ticker })}</p>
-        </ResponsiveTooltipContent>
-      </ResponsiveTooltip>
-    </div>
-  )
+  if (hasBalances === false) {
+    return (
+      <div className="flex w-full items-center justify-center rounded-md bg-[#2A1700] p-3 text-center">
+        <ResponsiveTooltip>
+          <ResponsiveTooltipTrigger
+            onClick={(e) => isDesktop && e.preventDefault()}
+          >
+            <div className={cn("flex items-center gap-2", className)}>
+              <AlertTriangle className="h-4 w-4" />
+              <span>Insufficient funds to place orders</span>
+            </div>
+          </ResponsiveTooltipTrigger>
+          <ResponsiveTooltipContent>
+            <p>{ORDER_FORM_DEPOSIT_WARNING({ ticker })}</p>
+          </ResponsiveTooltipContent>
+        </ResponsiveTooltip>
+      </div>
+    )
+  }
 }

--- a/app/trade/[base]/components/new-order/new-order-form.tsx
+++ b/app/trade/[base]/components/new-order/new-order-form.tsx
@@ -313,7 +313,7 @@ export function NewOrderForm({
                 <Button
                   className="flex w-full font-serif text-2xl font-bold tracking-tighter lg:tracking-normal"
                   disabled={
-                    !hasBalances ||
+                    hasBalances === false ||
                     !form.formState.isValid ||
                     isMaxOrders ||
                     (maintenanceMode?.enabled &&
@@ -380,7 +380,7 @@ export function NewOrderForm({
           <Button
             className="flex-1 font-extended text-lg"
             disabled={
-              !hasBalances ||
+              hasBalances === false ||
               !form.formState.isValid ||
               isMaxOrders ||
               (maintenanceMode?.enabled &&

--- a/components/dialogs/order-stepper/desktop/new-order-stepper.tsx
+++ b/components/dialogs/order-stepper/desktop/new-order-stepper.tsx
@@ -34,7 +34,7 @@ export function NewOrderStepperInner({
     >
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent
-        className="p-0 sm:max-w-[425px]"
+        className="gap-0 p-0 sm:max-w-[425px]"
         onOpenAutoFocus={(e) => {
           e.preventDefault()
         }}


### PR DESCRIPTION
This PR prevents the flash of "Insufficient Balances" warning due to wallet data having to hydrate after page load.