### PR TITLE
order form: prevent setting 0 amount when converting

### DIFF
--- a/app/trade/[base]/components/new-order/new-order-form.tsx
+++ b/app/trade/[base]/components/new-order/new-order-form.tsx
@@ -110,9 +110,11 @@ export function NewOrderForm({
       if (name === "isUSDCDenominated") {
         setIsUSDCDenominated(value.isUSDCDenominated ?? false)
         if (value.isUSDCDenominated) {
-          form.setValue("amount", priceInUsd)
+          if (Number(priceInUsd) > 0) {
+            form.setValue("amount", priceInUsd)
+          }
         } else {
-          if (price !== 0) {
+          if (Number(priceInBase) > 0) {
             form.setValue("amount", priceInBase)
           }
         }


### PR DESCRIPTION
This PR prevents the denomination switch button from populating a "0" in the input box when there was no previous input to convert.