### PR TITLE
maintenance mode: use maintenance wrapper for buttons

### DIFF
--- a/app/components/maintenance-banner.tsx
+++ b/app/components/maintenance-banner.tsx
@@ -1,20 +1,33 @@
-import React, { useEffect, useState } from "react"
+import React from "react"
 
 import { AlertCircle, AlertTriangle, Info } from "lucide-react"
 
 import { useMaintenanceMode } from "@/hooks/use-maintenance-mode"
 
+const isProduction = process.env.NEXT_PUBLIC_VERCEL_ENV === "production"
+
 export function MaintenanceBanner() {
   const { data: maintenanceMode, isLoading } = useMaintenanceMode()
-  const [isVisible, setIsVisible] = useState(false)
+  const [isVisible, setIsVisible] = React.useState(false)
 
-  useEffect(() => {
-    if (!isLoading && maintenanceMode?.enabled) {
+  React.useEffect(() => {
+    const isCriticalMaintenance =
+      isProduction &&
+      maintenanceMode?.enabled &&
+      maintenanceMode.severity === "critical"
+    console.log("debug", {
+      isCriticalMaintenance,
+      maintenanceMode: maintenanceMode?.bannerMessage,
+      enabled: maintenanceMode?.enabled,
+      severity: maintenanceMode?.severity,
+      isProduction,
+    })
+    if (isCriticalMaintenance) {
       setTimeout(() => setIsVisible(true), 100)
     } else {
       setIsVisible(false)
     }
-  }, [isLoading, maintenanceMode?.enabled])
+  }, [maintenanceMode])
 
   const getBgColor = () => {
     switch (maintenanceMode?.severity) {

--- a/app/orders/data-table.tsx
+++ b/app/orders/data-table.tsx
@@ -21,11 +21,7 @@ import { OrderDetailsSheet } from "@/app/trade/[base]/components/order-details/o
 import { TableEmptyState } from "@/components/table-empty-state"
 import { TableSelect } from "@/components/table-select"
 import { Button } from "@/components/ui/button"
-import {
-  ResponsiveTooltip,
-  ResponsiveTooltipContent,
-  ResponsiveTooltipTrigger,
-} from "@/components/ui/responsive-tooltip"
+import { MaintenanceButtonWrapper } from "@/components/ui/maintenance-button-wrapper"
 import {
   Table,
   TableBody,
@@ -42,7 +38,6 @@ import {
 } from "@/components/ui/tooltip"
 
 import { useCancelAllOrders } from "@/hooks/use-cancel-all-orders"
-import { useMaintenanceMode } from "@/hooks/use-maintenance-mode"
 import { ExtendedOrderMetadata } from "@/hooks/use-order-table-data"
 import { DISPLAY_TOKENS } from "@/lib/token"
 import { cn } from "@/lib/utils"
@@ -173,8 +168,6 @@ export function DataTable<TData, TValue>({
     table.getColumn("mint")?.setFilterValue(mint)
   }, [mint, table])
 
-  const { data: maintenanceMode } = useMaintenanceMode()
-
   return (
     <>
       <div className="flex flex-wrap items-center gap-2 lg:gap-4">
@@ -211,36 +204,17 @@ export function DataTable<TData, TValue>({
             Clear
           </Button>
         ) : null}
-        <ResponsiveTooltip>
-          <ResponsiveTooltipTrigger
-            asChild
-            className="sm:ml-auto"
+        <MaintenanceButtonWrapper messageKey="cancel">
+          <Button
+            className="text-muted-foreground sm:ml-auto"
+            disabled={isDisabled}
+            size="sm"
+            variant="outline"
+            onClick={handleCancelAllOrders}
           >
-            <Button
-              className="text-muted-foreground"
-              disabled={
-                isDisabled ||
-                (maintenanceMode?.enabled &&
-                  maintenanceMode.severity === "critical")
-              }
-              size="sm"
-              variant="outline"
-              onClick={handleCancelAllOrders}
-            >
-              Cancel all open orders
-            </Button>
-          </ResponsiveTooltipTrigger>
-          <ResponsiveTooltipContent
-            className={
-              maintenanceMode?.enabled &&
-              maintenanceMode.severity === "critical"
-                ? "visible"
-                : "invisible"
-            }
-          >
-            {`Cancelling orders is temporarily disabled${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`}
-          </ResponsiveTooltipContent>
-        </ResponsiveTooltip>
+            Cancel all open orders
+          </Button>
+        </MaintenanceButtonWrapper>
         <Tooltip>
           <TooltipTrigger asChild>
             <Toggle

--- a/app/trade/[base]/components/new-order/new-order-form.tsx
+++ b/app/trade/[base]/components/new-order/new-order-form.tsx
@@ -29,18 +29,13 @@ import {
   FormMessage,
 } from "@/components/ui/form"
 import { Label } from "@/components/ui/label"
-import {
-  ResponsiveTooltip,
-  ResponsiveTooltipContent,
-  ResponsiveTooltipTrigger,
-} from "@/components/ui/responsive-tooltip"
+import { MaintenanceButtonWrapper } from "@/components/ui/maintenance-button-wrapper"
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
-import { useMaintenanceMode } from "@/hooks/use-maintenance-mode"
 import { useOrderValue } from "@/hooks/use-order-value"
 import { usePredictedFees } from "@/hooks/use-predicted-fees"
 import { usePriceQuery } from "@/hooks/use-price-query"
@@ -81,7 +76,6 @@ export function NewOrderForm({
   closeButton?: React.ReactNode
 }) {
   const { side, setSide } = useSide()
-  const { data: maintenanceMode } = useMaintenanceMode()
 
   const isMaxOrders = useIsMaxOrders()
   const { walletReadyState } = useWallets()
@@ -303,38 +297,21 @@ export function NewOrderForm({
 
         {walletReadyState === "READY" ? (
           <div className="hidden lg:block">
-            <ResponsiveTooltip>
-              <ResponsiveTooltipTrigger
-                asChild
-                className="!pointer-events-auto w-full"
-              >
-                <Button
-                  className="flex w-full font-serif text-2xl font-bold tracking-tighter lg:tracking-normal"
-                  disabled={
-                    hasBalances === false ||
-                    !form.formState.isValid ||
-                    isMaxOrders ||
-                    (maintenanceMode?.enabled &&
-                      maintenanceMode.severity === "critical")
-                  }
-                  size="xl"
-                  type="submit"
-                  variant="default"
-                >
-                  {form.getValues("isSell") ? "Sell" : "Buy"} {base}
-                </Button>
-              </ResponsiveTooltipTrigger>
-              <ResponsiveTooltipContent
-                className={
-                  maintenanceMode?.enabled &&
-                  maintenanceMode.severity === "critical"
-                    ? "visible"
-                    : "invisible"
+            <MaintenanceButtonWrapper messageKey="place">
+              <Button
+                className="flex w-full font-serif text-2xl font-bold tracking-tighter lg:tracking-normal"
+                disabled={
+                  hasBalances === false ||
+                  !form.formState.isValid ||
+                  isMaxOrders
                 }
+                size="xl"
+                type="submit"
+                variant="default"
               >
-                {`Placing orders is temporarily disabled${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`}
-              </ResponsiveTooltipContent>
-            </ResponsiveTooltip>
+                {form.getValues("isSell") ? "Sell" : "Buy"} {base}
+              </Button>
+            </MaintenanceButtonWrapper>
           </div>
         ) : (
           <ConnectButton className="flex w-full font-serif text-2xl font-bold tracking-tighter lg:tracking-normal" />
@@ -375,20 +352,22 @@ export function NewOrderForm({
         </div>
         <div className="mt-auto flex flex-row lg:hidden">
           {closeButton}
-          <Button
-            className="flex-1 font-extended text-lg"
-            disabled={
-              hasBalances === false ||
-              !form.formState.isValid ||
-              isMaxOrders ||
-              (maintenanceMode?.enabled &&
-                maintenanceMode.severity === "critical")
-            }
-            size="xl"
-            variant="default"
+          <MaintenanceButtonWrapper
+            messageKey="place"
+            triggerClassName="flex-1"
           >
-            {form.getValues("isSell") ? "Sell" : "Buy"} {base}
-          </Button>
+            <Button
+              className="w-full font-extended text-lg"
+              disabled={
+                hasBalances === false || !form.formState.isValid || isMaxOrders
+              }
+              size="xl"
+              type="submit"
+              variant="default"
+            >
+              {form.getValues("isSell") ? "Sell" : "Buy"} {base}
+            </Button>
+          </MaintenanceButtonWrapper>
         </div>
       </form>
     </Form>

--- a/app/trade/[base]/components/order-details/cancel-button.tsx
+++ b/app/trade/[base]/components/order-details/cancel-button.tsx
@@ -3,13 +3,8 @@ import { Loader2 } from "lucide-react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
-import {
-  ResponsiveTooltip,
-  ResponsiveTooltipContent,
-  ResponsiveTooltipTrigger,
-} from "@/components/ui/responsive-tooltip"
+import { MaintenanceButtonWrapper } from "@/components/ui/maintenance-button-wrapper"
 
-import { useMaintenanceMode } from "@/hooks/use-maintenance-mode"
 import { usePrepareCancelOrder } from "@/hooks/usePrepareCancelOrder"
 import { constructStartToastMessage } from "@/lib/constants/task"
 import { cn } from "@/lib/utils"
@@ -25,56 +20,39 @@ export function CancelButton({
 }) {
   const { request } = usePrepareCancelOrder({ id })
   const { cancelOrder } = useCancelOrder()
-  const { data: maintenanceMode } = useMaintenanceMode()
+
   return (
-    <ResponsiveTooltip>
-      <ResponsiveTooltipTrigger
-        asChild
-        className="!pointer-events-auto w-full"
-      >
-        <Button
-          autoFocus
-          className={cn("w-full flex-1", className)}
-          disabled={
-            isDisabled ||
-            (maintenanceMode?.enabled &&
-              maintenanceMode.severity === "critical")
-          }
-          variant="outline"
-          onClick={() =>
-            cancelOrder(
-              {
-                id,
-                request,
+    <MaintenanceButtonWrapper
+      messageKey="cancel"
+      triggerClassName="w-full "
+    >
+      <Button
+        autoFocus
+        className={cn("w-full flex-1", className)}
+        disabled={isDisabled}
+        variant="outline"
+        onClick={() =>
+          cancelOrder(
+            {
+              id,
+              request,
+            },
+            {
+              onSuccess: (data) => {
+                const message = constructStartToastMessage(
+                  UpdateType.CancelOrder,
+                )
+                toast.success(message, {
+                  id: data.taskId,
+                  icon: <Loader2 className="h-4 w-4 animate-spin text-black" />,
+                })
               },
-              {
-                onSuccess: (data) => {
-                  const message = constructStartToastMessage(
-                    UpdateType.CancelOrder,
-                  )
-                  toast.success(message, {
-                    id: data.taskId,
-                    icon: (
-                      <Loader2 className="h-4 w-4 animate-spin text-black" />
-                    ),
-                  })
-                },
-              },
-            )
-          }
-        >
-          Cancel Order
-        </Button>
-      </ResponsiveTooltipTrigger>
-      <ResponsiveTooltipContent
-        className={
-          maintenanceMode?.enabled && maintenanceMode.severity === "critical"
-            ? "visible"
-            : "invisible"
+            },
+          )
         }
       >
-        {`Cancelling orders is temporarily disabled${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`}
-      </ResponsiveTooltipContent>
-    </ResponsiveTooltip>
+        Cancel Order
+      </Button>
+    </MaintenanceButtonWrapper>
   )
 }

--- a/components/dialogs/transfer/default-form.tsx
+++ b/components/dialogs/transfer/default-form.tsx
@@ -45,6 +45,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form"
+import { MaintenanceButtonWrapper } from "@/components/ui/maintenance-button-wrapper"
 import {
   ResponsiveTooltip,
   ResponsiveTooltipContent,
@@ -59,7 +60,6 @@ import {
 import { useAllowanceRequired } from "@/hooks/use-allowance-required"
 import { useCheckChain } from "@/hooks/use-check-chain"
 import { useDeposit } from "@/hooks/use-deposit"
-import { useMaintenanceMode } from "@/hooks/use-maintenance-mode"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { useTransactionConfirmation } from "@/hooks/use-transaction-confirmation"
 import { useWaitForTask } from "@/hooks/use-wait-for-task"
@@ -95,7 +95,6 @@ export function DefaultForm({
 }) {
   const { checkChain } = useCheckChain()
   const isDesktop = useMediaQuery("(min-width: 1024px)")
-  const { data: maintenanceMode } = useMaintenanceMode()
   const isTradePage = usePathname().includes("/trade")
   const queryClient = useQueryClient()
   const router = useRouter()
@@ -609,37 +608,21 @@ export function DefaultForm({
           </div>
           {isDesktop ? (
             <DialogFooter>
-              <ResponsiveTooltip>
-                <ResponsiveTooltipTrigger
-                  asChild
-                  className="!pointer-events-auto"
-                  type="submit"
-                >
-                  <Button
-                    className="flex-1 border-0 border-t font-extended text-2xl"
-                    disabled={
-                      !form.formState.isValid ||
-                      (isDeposit && isMaxBalances) ||
-                      (maintenanceMode?.enabled &&
-                        maintenanceMode.severity === "critical")
-                    }
-                    size="xl"
-                    variant="outline"
-                  >
-                    {buttonText}
-                  </Button>
-                </ResponsiveTooltipTrigger>
-                <ResponsiveTooltipContent
-                  className={
-                    maintenanceMode?.enabled &&
-                    maintenanceMode.severity === "critical"
-                      ? "visible"
-                      : "invisible"
+              <MaintenanceButtonWrapper
+                messageKey="transfer"
+                triggerClassName="flex-1"
+              >
+                <Button
+                  className="flex-1 border-0 border-t font-extended text-2xl"
+                  disabled={
+                    !form.formState.isValid || (isDeposit && isMaxBalances)
                   }
+                  size="xl"
+                  variant="outline"
                 >
-                  {`Transfers are temporarily disabled${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`}
-                </ResponsiveTooltipContent>
-              </ResponsiveTooltip>
+                  {buttonText}
+                </Button>
+              </MaintenanceButtonWrapper>
             </DialogFooter>
           ) : (
             <DialogFooter className="mt-auto flex-row">
@@ -652,33 +635,21 @@ export function DefaultForm({
                   Close
                 </Button>
               </DialogClose>
-              <ResponsiveTooltip>
-                <ResponsiveTooltipTrigger className="flex-1">
-                  <Button
-                    className="w-full whitespace-normal border-l-0 font-extended text-lg"
-                    disabled={
-                      !form.formState.isValid ||
-                      (isDeposit && isMaxBalances) ||
-                      (maintenanceMode?.enabled &&
-                        maintenanceMode.severity === "critical")
-                    }
-                    size="xl"
-                    variant="outline"
-                  >
-                    {buttonText}
-                  </Button>
-                </ResponsiveTooltipTrigger>
-                <ResponsiveTooltipContent
-                  className={
-                    maintenanceMode?.enabled &&
-                    maintenanceMode.severity === "critical"
-                      ? "visible"
-                      : "invisible"
+              <MaintenanceButtonWrapper
+                messageKey="transfer"
+                triggerClassName="flex-1"
+              >
+                <Button
+                  className="w-full whitespace-normal border-l-0 font-extended text-lg"
+                  disabled={
+                    !form.formState.isValid || (isDeposit && isMaxBalances)
                   }
+                  size="xl"
+                  variant="outline"
                 >
-                  {`Transfers are temporarily disabled${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`}
-                </ResponsiveTooltipContent>
-              </ResponsiveTooltip>
+                  {buttonText}
+                </Button>
+              </MaintenanceButtonWrapper>
             </DialogFooter>
           )}
         </form>

--- a/components/dialogs/transfer/usdc-form.tsx
+++ b/components/dialogs/transfer/usdc-form.tsx
@@ -56,18 +56,13 @@ import {
   FormMessage,
 } from "@/components/ui/form"
 import { Label } from "@/components/ui/label"
-import {
-  ResponsiveTooltip,
-  ResponsiveTooltipContent,
-  ResponsiveTooltipTrigger,
-} from "@/components/ui/responsive-tooltip"
+import { MaintenanceButtonWrapper } from "@/components/ui/maintenance-button-wrapper"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 
 import { useAllowanceRequired } from "@/hooks/use-allowance-required"
 import { useCheckChain } from "@/hooks/use-check-chain"
 import { useDeposit } from "@/hooks/use-deposit"
-import { useMaintenanceMode } from "@/hooks/use-maintenance-mode"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { useSwapConfirmation } from "@/hooks/use-swap-confirmation"
 import { useTransactionConfirmation } from "@/hooks/use-transaction-confirmation"
@@ -110,7 +105,6 @@ export function USDCForm({
   const { address } = useAccount()
   const { checkChain } = useCheckChain()
   const isMaxBalances = useIsMaxBalances(USDC_L2_TOKEN.address)
-  const { data: maintenanceMode } = useMaintenanceMode()
   const isDesktop = useMediaQuery("(min-width: 1024px)")
   const queryClient = useQueryClient()
   const { setSide } = useSide()
@@ -223,7 +217,7 @@ export function USDCForm({
     return (
       isFirstStep && isCrosschainTransfer && hasValidAmount && hasSolanaWallet
     )
-  }, [currentStep, network, chain.id, amount, solanaWallet.isConnected])
+  }, [amount, currentStep, network, solanaWallet.isConnected])
 
   const [debouncedAmount] = useDebounceValue(() => {
     if (network !== chain.id) return amount
@@ -938,7 +932,6 @@ export function USDCForm({
   const isSubmitDisabled =
     !form.formState.isValid ||
     isMaxBalances ||
-    (maintenanceMode?.enabled && maintenanceMode.severity === "critical") ||
     (swapRequired && (isQuoteFetching || !swapQuote)) ||
     (bridgeRequired &&
       (bridgeQuoteFetchStatus === "fetching" || !bridgeQuote)) ||
@@ -1211,32 +1204,19 @@ export function USDCForm({
           </ScrollArea>
           {isDesktop ? (
             <DialogFooter>
-              <ResponsiveTooltip>
-                <ResponsiveTooltipTrigger
-                  asChild
-                  className="!pointer-events-auto"
-                  type="submit"
+              <MaintenanceButtonWrapper
+                messageKey="transfer"
+                triggerClassName="flex-1"
+              >
+                <Button
+                  className="flex-1 border-0 border-t font-extended text-2xl"
+                  disabled={isSubmitDisabled}
+                  size="xl"
+                  variant="outline"
                 >
-                  <Button
-                    className="flex-1 border-0 border-t font-extended text-2xl"
-                    disabled={isSubmitDisabled}
-                    size="xl"
-                    variant="outline"
-                  >
-                    {buttonText}
-                  </Button>
-                </ResponsiveTooltipTrigger>
-                <ResponsiveTooltipContent
-                  className={
-                    maintenanceMode?.enabled &&
-                    maintenanceMode.severity === "critical"
-                      ? "visible"
-                      : "invisible"
-                  }
-                >
-                  {`Transfers are temporarily disabled${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`}
-                </ResponsiveTooltipContent>
-              </ResponsiveTooltip>
+                  {buttonText}
+                </Button>
+              </MaintenanceButtonWrapper>
             </DialogFooter>
           ) : (
             <DialogFooter className="mt-auto flex-row">
@@ -1249,28 +1229,19 @@ export function USDCForm({
                   Close
                 </Button>
               </DialogClose>
-              <ResponsiveTooltip>
-                <ResponsiveTooltipTrigger className="flex-1">
-                  <Button
-                    className="flex w-full flex-col items-center justify-center whitespace-normal text-pretty border-l-0 font-extended text-lg"
-                    disabled={isSubmitDisabled}
-                    size="xl"
-                    variant="outline"
-                  >
-                    {buttonText}
-                  </Button>
-                </ResponsiveTooltipTrigger>
-                <ResponsiveTooltipContent
-                  className={
-                    maintenanceMode?.enabled &&
-                    maintenanceMode.severity === "critical"
-                      ? "visible"
-                      : "invisible"
-                  }
+              <MaintenanceButtonWrapper
+                messageKey="transfer"
+                triggerClassName="flex-1"
+              >
+                <Button
+                  className="flex w-full flex-col items-center justify-center whitespace-normal text-pretty border-l-0 font-extended text-lg"
+                  disabled={isSubmitDisabled}
+                  size="xl"
+                  variant="outline"
                 >
-                  {`Transfers are temporarily disabled${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`}
-                </ResponsiveTooltipContent>
-              </ResponsiveTooltip>
+                  {buttonText}
+                </Button>
+              </MaintenanceButtonWrapper>
             </DialogFooter>
           )}
         </form>

--- a/components/dialogs/transfer/weth-form.tsx
+++ b/components/dialogs/transfer/weth-form.tsx
@@ -47,6 +47,7 @@ import {
   FormMessage,
 } from "@/components/ui/form"
 import { Label } from "@/components/ui/label"
+import { MaintenanceButtonWrapper } from "@/components/ui/maintenance-button-wrapper"
 import {
   ResponsiveTooltip,
   ResponsiveTooltipContent,
@@ -64,7 +65,6 @@ import { useAllowanceRequired } from "@/hooks/use-allowance-required"
 import { useBasePerQuotePrice } from "@/hooks/use-base-per-usd-price"
 import { useCheckChain } from "@/hooks/use-check-chain"
 import { useDeposit } from "@/hooks/use-deposit"
-import { useMaintenanceMode } from "@/hooks/use-maintenance-mode"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { useOnChainBalances } from "@/hooks/use-on-chain-balances"
 import { useTransactionConfirmation } from "@/hooks/use-transaction-confirmation"
@@ -114,7 +114,6 @@ export function WETHForm({
   const { checkChain } = useCheckChain()
   const isMaxBalances = useIsMaxBalances(WETH_L2_TOKEN.address)
   const isDesktop = useMediaQuery("(min-width: 1024px)")
-  const { data: maintenanceMode } = useMaintenanceMode()
   const isTradePage = usePathname().includes("/trade")
   const queryClient = useQueryClient()
   const router = useRouter()
@@ -915,37 +914,21 @@ export function WETHForm({
           </ScrollArea>
           {isDesktop ? (
             <DialogFooter>
-              <ResponsiveTooltip>
-                <ResponsiveTooltipTrigger
-                  asChild
-                  className="!pointer-events-auto"
-                  type="submit"
-                >
-                  <Button
-                    className="flex-1 border-0 border-t font-extended text-2xl"
-                    disabled={
-                      !form.formState.isValid ||
-                      (isDeposit && isMaxBalances) ||
-                      (maintenanceMode?.enabled &&
-                        maintenanceMode.severity === "critical")
-                    }
-                    size="xl"
-                    variant="outline"
-                  >
-                    {buttonText}
-                  </Button>
-                </ResponsiveTooltipTrigger>
-                <ResponsiveTooltipContent
-                  className={
-                    maintenanceMode?.enabled &&
-                    maintenanceMode.severity === "critical"
-                      ? "visible"
-                      : "invisible"
+              <MaintenanceButtonWrapper
+                messageKey="transfer"
+                triggerClassName="flex-1"
+              >
+                <Button
+                  className="flex-1 border-0 border-t font-extended text-2xl"
+                  disabled={
+                    !form.formState.isValid || (isDeposit && isMaxBalances)
                   }
+                  size="xl"
+                  variant="outline"
                 >
-                  {`Transfers are temporarily disabled${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`}
-                </ResponsiveTooltipContent>
-              </ResponsiveTooltip>
+                  {buttonText}
+                </Button>
+              </MaintenanceButtonWrapper>
             </DialogFooter>
           ) : (
             <DialogFooter className="mt-auto flex-row">
@@ -958,33 +941,21 @@ export function WETHForm({
                   Close
                 </Button>
               </DialogClose>
-              <ResponsiveTooltip>
-                <ResponsiveTooltipTrigger className="flex-1">
-                  <Button
-                    className="flex w-full flex-col items-center justify-center whitespace-normal text-pretty border-l-0 font-extended text-lg"
-                    disabled={
-                      !form.formState.isValid ||
-                      (isDeposit && isMaxBalances) ||
-                      (maintenanceMode?.enabled &&
-                        maintenanceMode.severity === "critical")
-                    }
-                    size="xl"
-                    variant="outline"
-                  >
-                    {buttonText}
-                  </Button>
-                </ResponsiveTooltipTrigger>
-                <ResponsiveTooltipContent
-                  className={
-                    maintenanceMode?.enabled &&
-                    maintenanceMode.severity === "critical"
-                      ? "visible"
-                      : "invisible"
+              <MaintenanceButtonWrapper
+                messageKey="transfer"
+                triggerClassName="flex-1"
+              >
+                <Button
+                  className="flex w-full flex-col items-center justify-center whitespace-normal text-pretty border-l-0 font-extended text-lg"
+                  disabled={
+                    !form.formState.isValid || (isDeposit && isMaxBalances)
                   }
+                  size="xl"
+                  variant="outline"
                 >
-                  {`Transfers are temporarily disabled${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`}
-                </ResponsiveTooltipContent>
-              </ResponsiveTooltip>
+                  {buttonText}
+                </Button>
+              </MaintenanceButtonWrapper>
             </DialogFooter>
           )}
         </form>

--- a/components/ui/maintenance-button-wrapper.tsx
+++ b/components/ui/maintenance-button-wrapper.tsx
@@ -1,0 +1,57 @@
+import * as React from "react"
+import {
+  ResponsiveTooltip,
+  ResponsiveTooltipContent,
+  ResponsiveTooltipTrigger,
+} from "@/components/ui/responsive-tooltip"
+import { useMaintenanceMode } from "@/hooks/use-maintenance-mode"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { MAINTENANCE_MESSAGES, MaintenanceMessageKey } from "@/lib/constants/maintenance"
+import { cn } from "@/lib/utils"
+
+interface MaintenanceButtonWrapperProps {
+  children: React.ReactElement<React.ButtonHTMLAttributes<HTMLButtonElement>>;
+  messageKey?: MaintenanceMessageKey;
+  message?: string;
+  triggerClassName?: string;
+}
+
+  const isProduction = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" 
+
+export function MaintenanceButtonWrapper({
+  children,
+  messageKey = "default",
+  message,
+  triggerClassName,
+}: MaintenanceButtonWrapperProps) {
+  const { data: maintenanceMode } = useMaintenanceMode()
+  const isMobile = useIsMobile()
+
+  const isCriticalMaintenance = isProduction && maintenanceMode?.enabled && maintenanceMode.severity === "critical"
+
+  const maintenanceMessage = React.useMemo(() => {
+    const baseMessage = message ?? MAINTENANCE_MESSAGES[messageKey]
+    return `${baseMessage}${maintenanceMode?.reason ? ` ${maintenanceMode.reason}` : ""}.`
+  }, [message, messageKey, maintenanceMode?.reason])
+
+  const buttonWithMaintenance = React.cloneElement(children, {
+    ...children.props,
+    disabled: Boolean(children.props.disabled) || isCriticalMaintenance,
+  } as React.ButtonHTMLAttributes<HTMLButtonElement>)
+
+  return (
+    <ResponsiveTooltip>
+      <ResponsiveTooltipTrigger 
+        asChild={!isMobile}
+        className={cn("!pointer-events-auto", triggerClassName)}
+      >
+        {buttonWithMaintenance}
+      </ResponsiveTooltipTrigger>
+      <ResponsiveTooltipContent
+        className={isCriticalMaintenance ? "visible" : "invisible"}
+      >
+        {maintenanceMessage}
+      </ResponsiveTooltipContent>
+    </ResponsiveTooltip>
+  )
+} 

--- a/hooks/use-maintenance-mode.ts
+++ b/hooks/use-maintenance-mode.ts
@@ -14,6 +14,9 @@ export function useMaintenanceMode() {
   return useQuery<MaintenanceMode, Error>({
     queryKey: ["maintenanceMode"],
     queryFn: fetchMaintenanceMode,
+    select: (data) => ({
+      ...data,
+    }),
     staleTime: 0,
   })
 }

--- a/lib/constants/maintenance.ts
+++ b/lib/constants/maintenance.ts
@@ -1,0 +1,8 @@
+export const MAINTENANCE_MESSAGES = {
+  place: "Placing orders is temporarily disabled",
+  cancel: "Cancelling orders is temporarily disabled",
+  transfer: "Transfers are temporarily disabled",
+  default: "This action is temporarily disabled",
+} as const
+
+export type MaintenanceMessageKey = keyof typeof MAINTENANCE_MESSAGES


### PR DESCRIPTION
This PR unifies logic regarding maintenance mode and also ensures it is only active in prod (not testnet).

TODO:
- [x] ensure maintenance mode disables all buttons correctly in prod