### PR TITLE
order panel: show external orders option only when placing order

### DIFF
--- a/components/dialogs/order-stepper/desktop/new-order-stepper.tsx
+++ b/components/dialogs/order-stepper/desktop/new-order-stepper.tsx
@@ -48,22 +48,21 @@ export function NewOrderStepperInner({
             )}
             {step === Step.SUCCESS && <SuccessStepWithoutSavings />}
           </div>
-          <div
-            className={cn(
-              "relative hidden max-h-fit whitespace-nowrap border bg-background lg:block",
-              {
-                hidden: step !== Step.DEFAULT,
-              },
-            )}
-          >
-            <div className="space-y-6 p-6">
-              <IOISection
-                {...props}
-                allowExternalMatches={allowExternalMatches}
-                setAllowExternalMatches={setAllowExternalMatches}
-              />
+          {step === Step.DEFAULT && (
+            <div
+              className={cn(
+                "relative hidden max-h-fit whitespace-nowrap border bg-background lg:block",
+              )}
+            >
+              <div className="space-y-6 p-6">
+                <IOISection
+                  {...props}
+                  allowExternalMatches={allowExternalMatches}
+                  setAllowExternalMatches={setAllowExternalMatches}
+                />
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
This PR ensures the external orders option is only available when placing an order, not during the success step.