### PR TITLE
transfer dialog: allow chain switch when approving eth bridge

### DIFF
--- a/components/dialogs/transfer/default-form.tsx
+++ b/components/dialogs/transfer/default-form.tsx
@@ -618,6 +618,7 @@ export function DefaultForm({
                     !form.formState.isValid || (isDeposit && isMaxBalances)
                   }
                   size="xl"
+                  type="submit"
                   variant="outline"
                 >
                   {buttonText}
@@ -645,6 +646,7 @@ export function DefaultForm({
                     !form.formState.isValid || (isDeposit && isMaxBalances)
                   }
                   size="xl"
+                  type="submit"
                   variant="outline"
                 >
                   {buttonText}

--- a/components/dialogs/transfer/usdc-form.tsx
+++ b/components/dialogs/transfer/usdc-form.tsx
@@ -658,6 +658,7 @@ export function USDCForm({
       if (bridgeAllowanceRequired) {
         await switchChainAndInvoke(mainnet.id, async () =>
           handleApproveBridge({
+            chainId: mainnet.id,
             address: USDC_L1_TOKEN.address,
             args: [
               bridgeQuote?.estimate.approvalAddress as `0x${string}`,
@@ -1212,6 +1213,7 @@ export function USDCForm({
                   className="flex-1 border-0 border-t font-extended text-2xl"
                   disabled={isSubmitDisabled}
                   size="xl"
+                  type="submit"
                   variant="outline"
                 >
                   {buttonText}
@@ -1237,6 +1239,7 @@ export function USDCForm({
                   className="flex w-full flex-col items-center justify-center whitespace-normal text-pretty border-l-0 font-extended text-lg"
                   disabled={isSubmitDisabled}
                   size="xl"
+                  type="submit"
                   variant="outline"
                 >
                   {buttonText}

--- a/components/dialogs/transfer/weth-form.tsx
+++ b/components/dialogs/transfer/weth-form.tsx
@@ -924,6 +924,7 @@ export function WETHForm({
                     !form.formState.isValid || (isDeposit && isMaxBalances)
                   }
                   size="xl"
+                  type="submit"
                   variant="outline"
                 >
                   {buttonText}
@@ -951,6 +952,7 @@ export function WETHForm({
                     !form.formState.isValid || (isDeposit && isMaxBalances)
                   }
                   size="xl"
+                  type="submit"
                   variant="outline"
                 >
                   {buttonText}

--- a/providers/wagmi-provider/wagmi-provider.tsx
+++ b/providers/wagmi-provider/wagmi-provider.tsx
@@ -125,7 +125,8 @@ function SyncRenegadeWagmiState() {
         })
     }
 
-    checkConnections()
+    // TODO: Disabled because it prevents switching to Mainnet when bridging
+    // checkConnections()
   }, [chainId, connector, isConnected, wagmiConfig, disconnectWagmi])
 
   // When switching accounts in a wallet, we need to ensure the new account


### PR DESCRIPTION
This PR prevents a check meant to ensure the connected wallet was compatible with the app but was preventing the wallet from ever switching chains.