### PR TITLE
storage: manually rehydrate store on mount

### DIFF
--- a/providers/state-provider/server-store-provider.tsx
+++ b/providers/state-provider/server-store-provider.tsx
@@ -1,6 +1,12 @@
 "use client"
 
-import { createContext, useContext, useRef, type ReactNode } from "react"
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from "react"
 
 import { useStore } from "zustand"
 
@@ -34,6 +40,19 @@ export function ServerStoreProvider({
     )
     storeRef.current = createServerStore(initialState ?? initServerStore())
   }
+
+  const active = useRef(true)
+
+  useEffect(() => {
+    ;(async () => {
+      if (storeRef.current) {
+        await storeRef.current.persist.rehydrate()
+      }
+    })()
+    return () => {
+      active.current = false
+    }
+  }, [])
 
   return (
     <ServerStoreContext.Provider value={storeRef.current}>

--- a/providers/state-provider/server-store.ts
+++ b/providers/state-provider/server-store.ts
@@ -60,6 +60,7 @@ export const createServerStore = (
       }),
       {
         name: STORAGE_SERVER_STORE,
+        skipHydration: true,
         storage: createJSONStorage(() => createCookieStorage()),
       },
     ),


### PR DESCRIPTION
This PR manually hydrates the server store to avoid this error:
```
Error: Server Functions cannot be called during initial render. This would create a fetch waterfall. Try to use a Server Component to pass data to Client Components instead.
```