### PR TITLE
wagmi: disconnect renegade wallet if wagmi wallet is locked/disconnected

### DIFF
--- a/providers/wagmi-provider/wagmi-provider.tsx
+++ b/providers/wagmi-provider/wagmi-provider.tsx
@@ -129,6 +129,14 @@ function SyncRenegadeWagmiState() {
     // checkConnections()
   }, [chainId, connector, isConnected, wagmiConfig, disconnectWagmi])
 
+  // Handles the case where Renegade wallet is connected, but wagmi wallet is not
+  // Required because effect below does not catch locked wallet case
+  React.useEffect(() => {
+    if (!isConnected && config.state.seed) {
+      disconnect(config)
+    }
+  }, [config, connector, isConnected])
+
   // When switching accounts in a wallet, we need to ensure the new account
   // is the one that originally generated the seed in storage. This effect:
   // 1. Verifies the current account can sign the stored seed


### PR DESCRIPTION
This PR ensures that a user's Renegade wallet and Wagmi wallet are kept in sync by handling the case where the Wagmi wallet is unreachable but a Renegade wallet is in memory. This makes sure the entire UI shows correct data based on the connected wallet.