### PR TITLE
hooks: historical state client order & task history hooks

### DIFF
--- a/app/api/stats/cumulative-volume/route.ts
+++ b/app/api/stats/cumulative-volume/route.ts
@@ -3,7 +3,12 @@ import { DDogClient } from "@renegade-fi/internal-sdk"
 export const runtime = "edge"
 
 export async function GET(request: Request) {
-  const ddog = new DDogClient()
+  const ddog = new DDogClient(
+    process.env.DD_API_KEY,
+    process.env.DD_APP_KEY,
+    process.env.DD_ENV,
+    process.env.DD_SERVICE,
+  )
   try {
     const { searchParams } = new URL(request.url)
     const to = parseInt(searchParams.get("to") || "")

--- a/app/api/stats/historical-volume/route.ts
+++ b/app/api/stats/historical-volume/route.ts
@@ -3,7 +3,12 @@ import { DDogClient } from "@renegade-fi/internal-sdk"
 export const runtime = "edge"
 
 export async function GET(request: Request) {
-  const ddog = new DDogClient()
+  const ddog = new DDogClient(
+    process.env.DD_API_KEY,
+    process.env.DD_APP_KEY,
+    process.env.DD_ENV,
+    process.env.DD_SERVICE,
+  )
   try {
     const { searchParams } = new URL(request.url)
     const to = parseInt(searchParams.get("to") || "")

--- a/app/api/stats/set-historical-volume-kv/route.ts
+++ b/app/api/stats/set-historical-volume-kv/route.ts
@@ -30,7 +30,12 @@ export const maxDuration = 300
 export async function GET(req: NextRequest) {
   console.log("Starting cron job: set-volume-kv")
   try {
-    const ddog = new DDogClient()
+    const ddog = new DDogClient(
+      process.env.DD_API_KEY,
+      process.env.DD_APP_KEY,
+      process.env.DD_ENV,
+      process.env.DD_SERVICE,
+    )
     const { searchParams } = new URL(req.url)
     const params: SearchParams = {
       to: parseInt(searchParams.get("to") ?? String(DEFAULT_PARAMS.to)),

--- a/app/assets/page-client.tsx
+++ b/app/assets/page-client.tsx
@@ -2,7 +2,7 @@
 
 import React from "react"
 
-import { TaskType, Token, UpdateType, useTaskHistory } from "@renegade-fi/react"
+import { TaskType, Token, UpdateType } from "@renegade-fi/react"
 import { Info } from "lucide-react"
 import { formatUnits } from "viem/utils"
 
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/responsive-tooltip"
 
 import { useAssetsTableData } from "@/hooks/use-assets-table-data"
+import { useTaskHistory } from "@/hooks/use-task-history"
 import { ASSETS_TOOLTIP } from "@/lib/constants/tooltips"
 import { DISPLAY_TOKENS } from "@/lib/token"
 

--- a/app/components/order-toaster.tsx
+++ b/app/components/order-toaster.tsx
@@ -6,6 +6,7 @@ import {
   OrderMetadata,
   OrderState,
   Token,
+  useBackOfQueueWallet,
   useOrderHistoryWebSocket,
 } from "@renegade-fi/react"
 import { toast } from "sonner"

--- a/app/components/order-toaster.tsx
+++ b/app/components/order-toaster.tsx
@@ -6,12 +6,11 @@ import {
   OrderMetadata,
   OrderState,
   Token,
-  useBackOfQueueWallet,
-  useOrderHistory,
   useOrderHistoryWebSocket,
 } from "@renegade-fi/react"
 import { toast } from "sonner"
 
+import { useOrderHistory } from "@/hooks/use-order-history"
 import { formatNumber } from "@/lib/format"
 import { syncOrdersWithWalletState } from "@/lib/order"
 

--- a/app/components/task-history-sheet.tsx
+++ b/app/components/task-history-sheet.tsx
@@ -9,7 +9,6 @@ import {
   TaskType,
   Token,
   UpdateType,
-  useTaskHistory,
 } from "@renegade-fi/react"
 
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -22,6 +21,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet"
 
+import { useTaskHistory } from "@/hooks/use-task-history"
 import { formatNumber, formatRelativeTimestamp } from "@/lib/format"
 
 export function TaskHistorySheet({ children }: { children: React.ReactNode }) {

--- a/app/components/wallet-sidebar/hooks/use-unviewed-fills.ts
+++ b/app/components/wallet-sidebar/hooks/use-unviewed-fills.ts
@@ -1,6 +1,6 @@
 import React from "react"
 
-import { OrderMetadata } from "@renegade-fi/react"
+import { OrderMetadata, useBackOfQueueWallet } from "@renegade-fi/react"
 
 import {
   generateFillIdentifier,
@@ -8,6 +8,7 @@ import {
 } from "@/app/components/wallet-sidebar/hooks/use-viewed-fills"
 
 import { useOrderHistory } from "@/hooks/use-order-history"
+import { syncOrdersWithWalletState } from "@/lib/order"
 import { useClientStore } from "@/providers/state-provider/client-store-provider.tsx"
 
 export function useRecentUnviewedFills() {

--- a/app/components/wallet-sidebar/hooks/use-unviewed-fills.ts
+++ b/app/components/wallet-sidebar/hooks/use-unviewed-fills.ts
@@ -1,17 +1,13 @@
 import React from "react"
 
-import {
-  OrderMetadata,
-  useBackOfQueueWallet,
-  useOrderHistory,
-} from "@renegade-fi/react"
+import { OrderMetadata } from "@renegade-fi/react"
 
 import {
   generateFillIdentifier,
   useViewedFills,
 } from "@/app/components/wallet-sidebar/hooks/use-viewed-fills"
 
-import { syncOrdersWithWalletState } from "@/lib/order"
+import { useOrderHistory } from "@/hooks/use-order-history"
 import { useClientStore } from "@/providers/state-provider/client-store-provider.tsx"
 
 export function useRecentUnviewedFills() {

--- a/app/environment.d.ts
+++ b/app/environment.d.ts
@@ -4,6 +4,10 @@ declare global {
   namespace NodeJS {
     interface ProcessEnv {
       AMBERDATA_API_KEY: string
+      DD_ENV: string
+      DD_SERVICE: string
+      DD_APP_KEY: string
+      DD_API_KEY: string
       NEXT_PUBLIC_AMBERDATA_PROXY_URL: string
       NEXT_PUBLIC_BOT_SECRETS: string
       NEXT_PUBLIC_DARKPOOL_CONTRACT: `0x${string}`
@@ -13,6 +17,7 @@ declare global {
       NEXT_PUBLIC_PERMIT2_CONTRACT: `0x${string}`
       NEXT_PUBLIC_PRICE_REPORTER_URL: string
       NEXT_PUBLIC_RENEGADE_RELAYER_HOSTNAME: string
+      NEXT_PUBLIC_HISTORICAL_STATE_URL: string
       NEXT_PUBLIC_RPC_URL: string
       NEXT_PUBLIC_TOKEN_MAPPING: string
       NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: string

--- a/hooks/use-order-history.ts
+++ b/hooks/use-order-history.ts
@@ -1,0 +1,75 @@
+import { HistoricalStateClient } from "@renegade-fi/internal-sdk"
+import {
+  Config,
+  OrderMetadata,
+  useConfig,
+  UseOrderHistoryParameters,
+  UseOrderHistoryReturnType,
+  useOrderHistoryWebSocket,
+  useStatus,
+  useQuery,
+} from "@renegade-fi/react"
+import {
+  GetOrderHistoryData,
+  GetOrderHistoryQueryKey,
+  getOrderHistoryQueryOptions,
+} from "@renegade-fi/react/query"
+import { useQueryClient } from "@tanstack/react-query"
+
+export function useOrderHistory<selectData = GetOrderHistoryData>(
+  parameters: UseOrderHistoryParameters<selectData> = {},
+): UseOrderHistoryReturnType<selectData> {
+  const { query = {} } = parameters
+
+  const config = useConfig(parameters)
+  const status = useStatus(parameters)
+  const queryClient = useQueryClient()
+
+  const baseOptions = getOrderHistoryQueryOptions(config, {
+    ...parameters,
+  })
+  const options = {
+    ...baseOptions,
+    queryFn: getHistoricalStateOrderHistoryQueryFn(config),
+  }
+
+  const enabled = Boolean(status === "in relayer" && (query.enabled ?? true))
+
+  useOrderHistoryWebSocket({
+    enabled,
+    onUpdate: (incoming: OrderMetadata) => {
+      if (queryClient && options.queryKey) {
+        const existingMap =
+          queryClient.getQueryData<GetOrderHistoryData>(options.queryKey) ||
+          new Map()
+        const existingOrder = existingMap.get(incoming.id)
+
+        if (!existingOrder || incoming.state !== existingOrder.state) {
+          const newMap = new Map(existingMap)
+          newMap.set(incoming.id, incoming)
+          queryClient.setQueryData(options.queryKey, newMap)
+        }
+      }
+    },
+  })
+
+  return useQuery({ ...query, ...options, enabled })
+}
+
+function getHistoricalStateOrderHistoryQueryFn(config: Config) {
+  return async function queryFn({
+    queryKey,
+  }: {
+    queryKey: GetOrderHistoryQueryKey
+  }) {
+    const { scopeKey: _ } = queryKey[1]
+
+    const hseClient = new HistoricalStateClient(
+      process.env.NEXT_PUBLIC_HISTORICAL_STATE_URL,
+      config,
+    )
+    const history = await hseClient.getOrderHistory()
+
+    return history ?? null
+  }
+}

--- a/hooks/use-order-history.ts
+++ b/hooks/use-order-history.ts
@@ -9,6 +9,7 @@ import {
   useStatus,
   useQuery,
 } from "@renegade-fi/react"
+import { getOrderHistory } from "@renegade-fi/react/actions"
 import {
   GetOrderHistoryData,
   GetOrderHistoryQueryKey,
@@ -64,11 +65,17 @@ function getHistoricalStateOrderHistoryQueryFn(config: Config) {
   }) {
     const { scopeKey: _ } = queryKey[1]
 
-    const hseClient = new HistoricalStateClient(
-      process.env.NEXT_PUBLIC_HISTORICAL_STATE_URL,
-      config,
-    )
-    const history = await hseClient.getOrderHistory()
+    let history
+    if (process.env.NEXT_PUBLIC_HISTORICAL_STATE_URL) {
+      const hseClient = new HistoricalStateClient(
+        process.env.NEXT_PUBLIC_HISTORICAL_STATE_URL,
+        config,
+      )
+
+      history = await hseClient.getOrderHistory()
+    } else {
+      history = await getOrderHistory(config)
+    }
 
     return history ?? null
   }

--- a/hooks/use-order-table-data.ts
+++ b/hooks/use-order-table-data.ts
@@ -1,12 +1,9 @@
-import {
-  OrderMetadata,
-  Token,
-  useBackOfQueueWallet,
-  useOrderHistory,
-} from "@renegade-fi/react"
+import { OrderMetadata, Token } from "@renegade-fi/react"
 import { formatUnits } from "viem/utils"
 
 import { getVWAP, syncOrdersWithWalletState } from "@/lib/order"
+
+import { useOrderHistory } from "./use-order-history"
 
 export interface ExtendedOrderMetadata extends OrderMetadata {
   usdValue: number

--- a/hooks/use-order-table-data.ts
+++ b/hooks/use-order-table-data.ts
@@ -1,4 +1,4 @@
-import { OrderMetadata, Token } from "@renegade-fi/react"
+import { OrderMetadata, Token, useBackOfQueueWallet } from "@renegade-fi/react"
 import { formatUnits } from "viem/utils"
 
 import { getVWAP, syncOrdersWithWalletState } from "@/lib/order"

--- a/hooks/use-task-history.ts
+++ b/hooks/use-task-history.ts
@@ -1,0 +1,75 @@
+import { HistoricalStateClient } from "@renegade-fi/internal-sdk"
+import {
+  Config,
+  Task,
+  useConfig,
+  useQuery,
+  useStatus,
+  UseTaskHistoryParameters,
+  UseTaskHistoryReturnType,
+  useTaskHistoryWebSocket,
+} from "@renegade-fi/react"
+import {
+  GetTaskHistoryData,
+  GetTaskHistoryQueryKey,
+  getTaskHistoryQueryOptions,
+} from "@renegade-fi/react/query"
+import { useQueryClient } from "@tanstack/react-query"
+
+export function useTaskHistory<selectData = GetTaskHistoryData>(
+  parameters: UseTaskHistoryParameters<selectData> = {},
+): UseTaskHistoryReturnType<selectData> {
+  const { query = {} } = parameters
+
+  const config = useConfig(parameters)
+  const status = useStatus(parameters)
+  const queryClient = useQueryClient()
+
+  const baseOptions = getTaskHistoryQueryOptions(config, {
+    ...parameters,
+  })
+  const options = {
+    ...baseOptions,
+    queryFn: getHistoricalStateTaskHistoryQueryFn(config),
+  }
+
+  const enabled = Boolean(status === "in relayer" && (query.enabled ?? true))
+
+  useTaskHistoryWebSocket({
+    enabled,
+    onUpdate: (incoming: Task) => {
+      if (queryClient && options.queryKey) {
+        const existingMap =
+          queryClient.getQueryData<GetTaskHistoryData>(options.queryKey) ||
+          new Map()
+        const existingTask = existingMap.get(incoming.id)
+
+        if (!existingTask || incoming.state !== existingTask.state) {
+          const newMap = new Map(existingMap)
+          newMap.set(incoming.id, incoming)
+          queryClient.setQueryData(options.queryKey, newMap)
+        }
+      }
+    },
+  })
+
+  return useQuery({ ...query, ...options, enabled })
+}
+
+function getHistoricalStateTaskHistoryQueryFn(config: Config) {
+  return async function queryFn({
+    queryKey,
+  }: {
+    queryKey: GetTaskHistoryQueryKey
+  }) {
+    const { scopeKey: _ } = queryKey[1]
+
+    const hseClient = new HistoricalStateClient(
+      process.env.NEXT_PUBLIC_HISTORICAL_STATE_URL,
+      config,
+    )
+    const history = await hseClient.getTaskHistory()
+
+    return history ?? null
+  }
+}

--- a/hooks/use-task-history.ts
+++ b/hooks/use-task-history.ts
@@ -9,6 +9,7 @@ import {
   UseTaskHistoryReturnType,
   useTaskHistoryWebSocket,
 } from "@renegade-fi/react"
+import { getTaskHistory } from "@renegade-fi/react/actions"
 import {
   GetTaskHistoryData,
   GetTaskHistoryQueryKey,
@@ -64,11 +65,17 @@ function getHistoricalStateTaskHistoryQueryFn(config: Config) {
   }) {
     const { scopeKey: _ } = queryKey[1]
 
-    const hseClient = new HistoricalStateClient(
-      process.env.NEXT_PUBLIC_HISTORICAL_STATE_URL,
-      config,
-    )
-    const history = await hseClient.getTaskHistory()
+    let history
+    if (process.env.NEXT_PUBLIC_HISTORICAL_STATE_URL) {
+      const hseClient = new HistoricalStateClient(
+        process.env.NEXT_PUBLIC_HISTORICAL_STATE_URL,
+        config,
+      )
+
+      history = await hseClient.getTaskHistory()
+    } else {
+      history = await getTaskHistory(config)
+    }
 
     return history ?? null
   }

--- a/hooks/use-wait-for-task.ts
+++ b/hooks/use-wait-for-task.ts
@@ -1,6 +1,6 @@
 import React from "react"
 
-import { TaskState, useTaskHistory } from "@renegade-fi/react"
+import { useTaskHistory } from "./use-task-history"
 
 export function useWaitForTask(onConfirm?: () => void) {
   // TODO: Refactor useDeposit to useMutation and declaratively pass taskId from { data }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.0",
     "@radix-ui/react-visually-hidden": "^1.1.0",
-    "@renegade-fi/internal-sdk": "0.0.15",
-    "@renegade-fi/react": "0.0.0-canary-20250104172719",
+    "@renegade-fi/internal-sdk": "0.0.16",
+    "@renegade-fi/react": "0.4.16",
     "@renegade-fi/tradingview-charts": "0.27.6",
     "@solana/wallet-adapter-base": "^0.9.23",
     "@solana/wallet-adapter-react": "^0.15.35",
@@ -105,7 +105,7 @@
       "@types/react": "19.0.1",
       "@types/react-dom": "19.0.2",
       "react-is": "19.0.0",
-      "@renegade-fi/core": "0.4.12",
+      "@renegade-fi/core": "0.4.15",
       "viem": "$viem"
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.0",
     "@radix-ui/react-visually-hidden": "^1.1.0",
-    "@renegade-fi/internal-sdk": "0.0.0-canary-20240829175257",
-    "@renegade-fi/react": "0.4.12",
+    "@renegade-fi/internal-sdk": "0.0.15",
+    "@renegade-fi/react": "0.0.0-canary-20250104172719",
     "@renegade-fi/tradingview-charts": "0.27.6",
     "@solana/wallet-adapter-base": "^0.9.23",
     "@solana/wallet-adapter-react": "^0.15.35",
@@ -104,7 +104,9 @@
     "overrides": {
       "@types/react": "19.0.1",
       "@types/react-dom": "19.0.2",
-      "react-is": "19.0.0"
+      "react-is": "19.0.0",
+      "@renegade-fi/core": "0.4.12",
+      "viem": "$viem"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@types/react': 19.0.1
   '@types/react-dom': 19.0.2
   react-is: 19.0.0
-  '@renegade-fi/core': 0.4.12
+  '@renegade-fi/core': 0.4.15
   viem: ~2.15.1
 
 importers:
@@ -100,11 +100,11 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@renegade-fi/internal-sdk':
-        specifier: 0.0.15
-        version: 0.0.15(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(bufferutil@4.0.8)(react@19.0.0)(typescript@5.4.5)(utf-8-validate@5.0.10)(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(zod@3.23.8)
+        specifier: 0.0.16
+        version: 0.0.16(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(bufferutil@4.0.8)(react@19.0.0)(typescript@5.4.5)(utf-8-validate@5.0.10)(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(zod@3.23.8)
       '@renegade-fi/react':
-        specifier: 0.0.0-canary-20250104172719
-        version: 0.0.0-canary-20250104172719(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.0.0))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+        specifier: 0.4.16
+        version: 0.4.16(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.0.0))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@renegade-fi/tradingview-charts':
         specifier: 0.27.6
         version: 0.27.6
@@ -2798,8 +2798,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@renegade-fi/core@0.4.12':
-    resolution: {integrity: sha512-7DjxIr6GBeTOTcwwnoLDvGZ7S/ZY3KN4EkOCUwfSLTpel2ZSYVTNnYj5TsgRPjylBCw6u4fIyb3X1lw9OfbdgA==}
+  '@renegade-fi/core@0.4.15':
+    resolution: {integrity: sha512-32hutEQTO9Gd7KmKPKFteqqWPqOJ0XsWQixzUOxBH3VqLOMvCiSpMYQe19ByTT81twFY+O7SrGuunXhQGJZxXg==}
     peerDependencies:
       '@tanstack/query-core': '>=5.0.0'
       viem: ~2.15.1
@@ -2807,11 +2807,11 @@ packages:
       '@tanstack/query-core':
         optional: true
 
-  '@renegade-fi/internal-sdk@0.0.15':
-    resolution: {integrity: sha512-D7HSENDWL+ZrY4+3n/EUTT5md48SQoJrBI5gNx5Pv2I2U3YRfXtjp4l/ZsbDe9pSwxO8wr+wITI89q2uTfjmVA==}
+  '@renegade-fi/internal-sdk@0.0.16':
+    resolution: {integrity: sha512-NcZ/nXrtPU+tPlhaxjrNDsM3Zli5hZJzFLoriBogu/rkfmayKwT4Wqgn43+qwawnJilfLqyUFgz9sQAowFcDQg==}
 
-  '@renegade-fi/react@0.0.0-canary-20250104172719':
-    resolution: {integrity: sha512-d/rL8GHo0Cos3XdYc/UXNcJhIzeqAW4TeKJ7dedciKnZSfO3QkXYMUdVsB04+dmKjWZtffBERfpk9fxJBPpIhQ==}
+  '@renegade-fi/react@0.4.16':
+    resolution: {integrity: sha512-jcZdEeR5CTG84LZYkHargTSPaKnl0nuSbPuQAH8ilH90gTt0YT1B5XB3URsUurm83JIiDGCyO++GW3eGzdl1Gw==}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
@@ -11240,7 +11240,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.1
 
-  '@renegade-fi/core@0.4.12(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@renegade-fi/core@0.4.15(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       axios: 1.7.5
       isomorphic-ws: 5.0.0(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
@@ -11257,11 +11257,11 @@ snapshots:
       - react
       - ws
 
-  '@renegade-fi/internal-sdk@0.0.15(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(bufferutil@4.0.8)(react@19.0.0)(typescript@5.4.5)(utf-8-validate@5.0.10)(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(zod@3.23.8)':
+  '@renegade-fi/internal-sdk@0.0.16(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(bufferutil@4.0.8)(react@19.0.0)(typescript@5.4.5)(utf-8-validate@5.0.10)(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(zod@3.23.8)':
     dependencies:
       '@datadog/datadog-api-client': 1.27.0
       '@noble/hashes': 1.5.0
-      '@renegade-fi/core': 0.4.12(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@renegade-fi/core': 0.4.15(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       axios: 1.7.5
       json-bigint: 1.0.0
       tiny-invariant: 1.3.3
@@ -11279,9 +11279,9 @@ snapshots:
       - ws
       - zod
 
-  '@renegade-fi/react@0.0.0-canary-20250104172719(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.0.0))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@renegade-fi/react@0.4.16(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.0.0))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
-      '@renegade-fi/core': 0.4.12(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@renegade-fi/core': 0.4.15(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@tanstack/react-query': 5.45.1(react@19.0.0)
       json-bigint: 1.0.0
       react: 19.0.0
@@ -14257,8 +14257,8 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0)
       eslint-plugin-react: 7.37.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 5.0.0(eslint@8.57.0)
@@ -14280,13 +14280,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0):
     dependencies:
       debug: 4.3.6(supports-color@5.5.0)
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.15.1
@@ -14297,18 +14297,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -14319,7 +14319,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   '@types/react': 19.0.1
   '@types/react-dom': 19.0.2
   react-is: 19.0.0
+  '@renegade-fi/core': 0.4.12
+  viem: ~2.15.1
 
 importers:
 
@@ -98,11 +100,11 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@renegade-fi/internal-sdk':
-        specifier: 0.0.0-canary-20240829175257
-        version: 0.0.0-canary-20240829175257(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8)
+        specifier: 0.0.15
+        version: 0.0.15(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(bufferutil@4.0.8)(react@19.0.0)(typescript@5.4.5)(utf-8-validate@5.0.10)(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(zod@3.23.8)
       '@renegade-fi/react':
-        specifier: 0.4.12
-        version: 0.4.12(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.0.0))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+        specifier: 0.0.0-canary-20250104172719
+        version: 0.0.0-canary-20250104172719(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.0.0))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@renegade-fi/tradingview-charts':
         specifier: 0.27.6
         version: 0.27.6
@@ -1041,7 +1043,7 @@ packages:
     peerDependencies:
       bitcoinjs-lib: ^7.0.0-rc.0
       bs58: ^6.0.0
-      viem: ^2.21.0
+      viem: ~2.15.1
 
   '@coinbase/wallet-sdk@3.9.3':
     resolution: {integrity: sha512-N/A2DRIf0Y3PHc1XAMvbBUu4zisna6qAdqABMZwBMNEfWrXpAwx16pZGkYCLGE+Rvv1edbcB2LYDRnACNcmCiw==}
@@ -1537,7 +1539,7 @@ packages:
     peerDependencies:
       '@solana/wallet-adapter-base': ^0.9.0
       '@solana/web3.js': ^1.93.0
-      viem: ^2.16.0
+      viem: ~2.15.1
 
   '@lifi/types@16.2.2':
     resolution: {integrity: sha512-pgnN5NBcfvz9o2tonrQS6zSrpwldsu/NJ7cE45veRc1p7bLHaaVI8LLcFvAQxRip4kv7yS0QLLwp+MOBJUsyPQ==}
@@ -1732,9 +1734,6 @@ packages:
 
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
-
-  '@noble/curves@1.4.0':
-    resolution: {integrity: sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==}
 
   '@noble/curves@1.4.2':
     resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
@@ -2799,20 +2798,20 @@ packages:
       '@types/react':
         optional: true
 
-  '@renegade-fi/core@0.4.11':
-    resolution: {integrity: sha512-SyqmBjpcCvUC1LodLXzdPdI+o4z/FVeJhb1PLo9dgk0U6Ezen2BvxQ7s/QGxkC0zkNRhIRofTCiCckPM1ZZI3w==}
+  '@renegade-fi/core@0.4.12':
+    resolution: {integrity: sha512-7DjxIr6GBeTOTcwwnoLDvGZ7S/ZY3KN4EkOCUwfSLTpel2ZSYVTNnYj5TsgRPjylBCw6u4fIyb3X1lw9OfbdgA==}
     peerDependencies:
       '@tanstack/query-core': '>=5.0.0'
-      viem: 2.x
+      viem: ~2.15.1
     peerDependenciesMeta:
       '@tanstack/query-core':
         optional: true
 
-  '@renegade-fi/internal-sdk@0.0.0-canary-20240829175257':
-    resolution: {integrity: sha512-6X8eG5EdSjJAMCR2MCx8LSML83QUaMefjWY2MxO5Gi9DUdzjDhItVfWVmZ62Gf6JLoIiHzHP+DVVabRyw2k3fw==}
+  '@renegade-fi/internal-sdk@0.0.15':
+    resolution: {integrity: sha512-D7HSENDWL+ZrY4+3n/EUTT5md48SQoJrBI5gNx5Pv2I2U3YRfXtjp4l/ZsbDe9pSwxO8wr+wITI89q2uTfjmVA==}
 
-  '@renegade-fi/react@0.4.12':
-    resolution: {integrity: sha512-ZEJZHCDzgZS269FC+oRFBnMicnHyhv+EmymT+3xeRLPYS+vjaTOJBTUzDnfia9q96OYZtyKV7Y9wsxaTufxwHQ==}
+  '@renegade-fi/react@0.0.0-canary-20250104172719':
+    resolution: {integrity: sha512-d/rL8GHo0Cos3XdYc/UXNcJhIzeqAW4TeKJ7dedciKnZSfO3QkXYMUdVsB04+dmKjWZtffBERfpk9fxJBPpIhQ==}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
@@ -3680,7 +3679,7 @@ packages:
     peerDependencies:
       '@wagmi/core': 2.13.5
       typescript: '>=5.0.4'
-      viem: 2.x
+      viem: ~2.15.1
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3690,7 +3689,7 @@ packages:
     peerDependencies:
       '@tanstack/query-core': '>=5.0.0'
       typescript: '>=5.0.4'
-      viem: 2.x
+      viem: ~2.15.1
     peerDependenciesMeta:
       '@tanstack/query-core':
         optional: true
@@ -3839,17 +3838,6 @@ packages:
 
   abitype@1.0.4:
     resolution: {integrity: sha512-UivtYZOGJGE8rsrM/N5vdRkUpqEZVmuTumfTuolm7m/6O09wprd958rx8kUBwVAAAhQDveGAgD0GJdBuR8s6tw==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3 >=3.22.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
-
-  abitype@1.0.5:
-    resolution: {integrity: sha512-YzDhti7cjlfaBhHutMaboYB21Ha3rXR9QTkNJFzYC4kC8YclaiwPBBBJY8ejFdu2wnJeZCVZSMlQJ7fi8S6hsw==}
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3 >=3.22.0
@@ -4466,7 +4454,7 @@ packages:
       '@tanstack/react-query': '>=5.0.0'
       react: 17.x || 18.x
       react-dom: 17.x || 18.x
-      viem: 2.x
+      viem: ~2.15.1
       wagmi: 2.x
 
   consola@3.2.3:
@@ -7942,14 +7930,6 @@ packages:
       typescript:
         optional: true
 
-  viem@2.20.1:
-    resolution: {integrity: sha512-a/BSe25TSfkc423GTSKYl1O0ON2J5huoQeOLkylHT1WS8wh3JFqb8nfAq7vg+aZ+W06BCTn36bbi47yp4D92Cg==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
@@ -7959,7 +7939,7 @@ packages:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
       typescript: '>=5.0.4'
-      viem: 2.x
+      viem: ~2.15.1
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -7972,9 +7952,6 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
-
-  webauthn-p256@0.0.5:
-    resolution: {integrity: sha512-drMGNWKdaixZNobeORVIqq7k5DsRC9FnG201K2QjeOoQLmtSDaSsVZdkg6n5jUALJKcAG++zBPJXmv6hy0nWFg==}
 
   webextension-polyfill@0.10.0:
     resolution: {integrity: sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==}
@@ -10016,10 +9993,6 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.3.2
 
-  '@noble/curves@1.4.0':
-    dependencies:
-      '@noble/hashes': 1.4.0
-
   '@noble/curves@1.4.2':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -11267,7 +11240,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.1
 
-  '@renegade-fi/core@0.4.11(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@renegade-fi/core@0.4.12(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       axios: 1.7.5
       isomorphic-ws: 5.0.0(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
@@ -11284,24 +11257,31 @@ snapshots:
       - react
       - ws
 
-  '@renegade-fi/internal-sdk@0.0.0-canary-20240829175257(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8)':
+  '@renegade-fi/internal-sdk@0.0.15(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(bufferutil@4.0.8)(react@19.0.0)(typescript@5.4.5)(utf-8-validate@5.0.10)(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(zod@3.23.8)':
     dependencies:
       '@datadog/datadog-api-client': 1.27.0
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.5.0
+      '@renegade-fi/core': 0.4.12(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       axios: 1.7.5
+      json-bigint: 1.0.0
       tiny-invariant: 1.3.3
-      viem: 2.20.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8)
+      viem: 2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8)
     transitivePeerDependencies:
+      - '@tanstack/query-core'
+      - '@types/react'
       - bufferutil
       - debug
       - encoding
+      - immer
+      - react
       - typescript
       - utf-8-validate
+      - ws
       - zod
 
-  '@renegade-fi/react@0.4.12(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.0.0))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@renegade-fi/react@0.0.0-canary-20250104172719(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.0.0))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
-      '@renegade-fi/core': 0.4.11(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@renegade-fi/core': 0.4.12(@tanstack/query-core@5.45.0)(@types/react@19.0.1)(react@19.0.0)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@tanstack/react-query': 5.45.1(react@19.0.0)
       json-bigint: 1.0.0
       react: 19.0.0
@@ -13027,11 +13007,6 @@ snapshots:
       typescript: 5.4.5
       zod: 3.23.8
 
-  abitype@1.0.5(typescript@5.4.5)(zod@3.23.8):
-    optionalDependencies:
-      typescript: 5.4.5
-      zod: 3.23.8
-
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -13457,7 +13432,7 @@ snapshots:
 
   bs58check@4.0.0:
     dependencies:
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.5.0
       bs58: 6.0.0
 
   bser@2.1.1:
@@ -14282,8 +14257,8 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0)
       eslint-plugin-react: 7.37.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 5.0.0(eslint@8.57.0)
@@ -14305,13 +14280,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.6(supports-color@5.5.0)
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.15.1
@@ -14322,18 +14297,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -14344,7 +14319,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -17686,24 +17661,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.20.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8):
-    dependencies:
-      '@adraffy/ens-normalize': 1.10.0
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
-      '@scure/bip32': 1.4.0
-      '@scure/bip39': 1.3.0
-      abitype: 1.0.5(typescript@5.4.5)(zod@3.23.8)
-      isows: 1.0.4(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      webauthn-p256: 0.0.5
-      ws: 8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
   vlq@1.0.1: {}
 
   wagmi@2.12.11(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@19.0.1)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.0.0))(@types/react@19.0.1)(@upstash/redis@1.34.0)(@vercel/kv@2.0.0)(bufferutil@4.0.8)(react-dom@19.0.0(react@19.0.0))(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@19.0.1)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)(typescript@5.4.5)(utf-8-validate@5.0.10)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8):
@@ -17754,11 +17711,6 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
-
-  webauthn-p256@0.0.5:
-    dependencies:
-      '@noble/curves': 1.4.2
-      '@noble/hashes': 1.4.0
 
   webextension-polyfill@0.10.0: {}
 


### PR DESCRIPTION
This PR replaces the `useOrderHistory` and `useTaskHistory` hooks from the SDK w/ a version that queries the historical state engine, an internal service that makes historical state previously managed by the relayer more reliable & durable.

### Testing
- [x] Tested w/ a local relayer & frontend against testnet chain & historical state engine
- [x] Tested w/ testnet relayer & deployed preview frontend against testnet
- [ ] Parity testing (post-migration)