### PR TITLE
app: assets: set 1000-task limit for transfer history fetch

### DIFF
--- a/app/assets/page-client.tsx
+++ b/app/assets/page-client.tsx
@@ -53,6 +53,7 @@ export function PageClient() {
 
   // Transfer History Table Data
   const { data: transferHistory } = useTaskHistory({
+    limit: 1000,
     query: {
       select: (data) => Array.from(data.values()),
     },


### PR DESCRIPTION
This PR leverages the changes in https://github.com/renegade-fi/typescript-sdk/pull/149 to set a 1000-task limit for the task history fetch used to display transfer history. Using this large constant is a stopgap solution until historical state is fully integrated, which will support pagination at the API layer.

### Testing
This was tested by running a local frontend against the mainnet stack, where I asserted that I was able to fetch transfer history from further back for my wallet.