### PR TITLE
order history: filter non-terminal orders by wallet orders array

### DIFF
--- a/app/components/order-toaster.tsx
+++ b/app/components/order-toaster.tsx
@@ -6,12 +6,14 @@ import {
   OrderMetadata,
   OrderState,
   Token,
+  useBackOfQueueWallet,
   useOrderHistory,
   useOrderHistoryWebSocket,
 } from "@renegade-fi/react"
 import { toast } from "sonner"
 
 import { formatNumber } from "@/lib/format"
+import { syncOrdersWithWalletState } from "@/lib/order"
 
 export function OrderToaster() {
   const [incomingOrder, setIncomingOrder] = React.useState<OrderMetadata>()
@@ -22,9 +24,16 @@ export function OrderToaster() {
   })
   const orderMetadataRef = React.useRef<Map<string, OrderMetadata>>(new Map())
 
+  const { data: orderIds } = useBackOfQueueWallet({
+    query: {
+      select: (data) => data.orders.map((order) => order.id),
+    },
+  })
   const { data } = useOrderHistory({
     query: {
       enabled: orderMetadataRef.current.size === 0,
+      select: (data) =>
+        syncOrdersWithWalletState({ orders: data, walletOrderIds: orderIds }),
     },
   })
 

--- a/hooks/use-order-table-data.ts
+++ b/hooks/use-order-table-data.ts
@@ -1,16 +1,32 @@
-import { OrderMetadata, Token, useOrderHistory } from "@renegade-fi/react"
+import {
+  OrderMetadata,
+  Token,
+  useBackOfQueueWallet,
+  useOrderHistory,
+} from "@renegade-fi/react"
 import { formatUnits } from "viem/utils"
 
-import { getVWAP } from "@/lib/order"
+import { getVWAP, syncOrdersWithWalletState } from "@/lib/order"
 
 export interface ExtendedOrderMetadata extends OrderMetadata {
   usdValue: number
 }
 
 export function useOrderTableData() {
+  const { data: orderIds } = useBackOfQueueWallet({
+    query: {
+      select: (data) => data.orders.map((order) => order.id),
+    },
+  })
   const { data } = useOrderHistory({
     query: {
-      select: (data) => Array.from(data?.values() || []),
+      select: (data) => {
+        const filtered = syncOrdersWithWalletState({
+          orders: data,
+          walletOrderIds: orderIds,
+        })
+        return Array.from(filtered.values())
+      },
     },
   })
 


### PR DESCRIPTION
### Purpose
This PR adds filtering to ensure non-terminal orders (orders that are not Filled or Cancelled) shown in the UI are consistent with the wallet's current state. This fixes an issue where the order history could fall out of sync with the wallet's orders array, leading to stale or invalid orders being displayed.

Key changes:
- Adds `syncOrdersWithWalletState` utility function that filters orders based on wallet state
- Applies filtering in order-toaster, unviewed fills hook, and order table data
- Terminal orders (Filled/Cancelled) are always included regardless of wallet state
- Non-terminal orders must exist in wallet's current orders array to be displayed

This ensures users only see valid, active orders alongside their completed order history.

### Testing
- [x] Tested locally
- [x] Tested in testnet