### PR TITLE
create, cancel order: invoke req body generator async

### DIFF
--- a/app/trade/[base]/components/order-details/cancel-button.tsx
+++ b/app/trade/[base]/components/order-details/cancel-button.tsx
@@ -18,7 +18,7 @@ export function CancelButton({
   id: string
   isDisabled?: boolean
 }) {
-  const { request } = usePrepareCancelOrder({ id })
+  const { data: request } = usePrepareCancelOrder({ id })
   const { cancelOrder } = useCancelOrder()
 
   return (

--- a/components/dialogs/order-stepper/desktop/steps/default.tsx
+++ b/components/dialogs/order-stepper/desktop/steps/default.tsx
@@ -58,7 +58,7 @@ export function DefaultStep(
     return decimalCorrectPrice(wcp, baseToken.decimals, quoteToken.decimals)
   }, [baseToken.decimals, price, props.isSell, quoteToken.decimals])
 
-  const { request } = usePrepareCreateOrder({
+  const { data: request } = usePrepareCreateOrder({
     base: baseToken.address,
     quote: quoteToken.address,
     side: props.isSell ? "sell" : "buy",

--- a/components/dialogs/order-stepper/mobile/steps/confirm.tsx
+++ b/components/dialogs/order-stepper/mobile/steps/confirm.tsx
@@ -34,7 +34,7 @@ export function ConfirmStep(props: NewOrderConfirmationProps) {
     return decimalCorrectPrice(wcp, baseToken.decimals, quoteToken.decimals)
   }, [baseToken.decimals, price, props.isSell, quoteToken.decimals])
 
-  const { request } = usePrepareCreateOrder({
+  const { data: request } = usePrepareCreateOrder({
     base: baseToken.address,
     quote: quoteToken.address,
     side: props.isSell ? "sell" : "buy",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7514,6 +7514,7 @@ packages:
 
   sudo-prompt@9.2.1:
     resolution: {integrity: sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   superstruct@1.0.4:
     resolution: {integrity: sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==}


### PR DESCRIPTION
### Purpose
This PR updates the prepare order hooks to handle the new async invocation of request body generators from the SDK. The main changes:

- Migrates usePrepareCreateOrder and usePrepareCancelOrder to use React Query
- Updates components to use data property from query result instead of request
- Converts error returns to throws for proper async error handling
- Adds proper query enabling conditions
- Updates @renegade-fi/react to 0.4.15

No functional changes, just handling the async nature of the new SDK methods.

Intentionally does not bump the SDK version, will leave that for separate PR.

### Testing
- [x] Tested locally
- [x] Tested in testnet
- [x] Ensure backwards compatible