### PR TITLE
cancel order: fix query for cancel order req body

### DIFF
--- a/app/trade/[base]/components/order-details/cancel-button.tsx
+++ b/app/trade/[base]/components/order-details/cancel-button.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { MaintenanceButtonWrapper } from "@/components/ui/maintenance-button-wrapper"
 
-import { usePrepareCancelOrder } from "@/hooks/usePrepareCancelOrder"
+import { usePrepareCancelOrder } from "@/hooks/use-prepare-cancel-order"
 import { constructStartToastMessage } from "@/lib/constants/task"
 import { cn } from "@/lib/utils"
 

--- a/hooks/use-prepare-cancel-order.ts
+++ b/hooks/use-prepare-cancel-order.ts
@@ -29,7 +29,7 @@ export function usePrepareCancelOrder(
           id,
         )
       }
-      return undefined
+      return null
     },
     enabled: Boolean(config.state.seed),
   })


### PR DESCRIPTION
### Purpose
This PR fixes a bug where the query function for the cancel order body request returned undefined, which is invalid behavior according to Tanstack Query docs.

### Testing
- [x] Tested locally
- [x] Test in testnet