### PR TITLE
query: prevent price query invalidation

### DIFF
--- a/app/components/invalidate-queries.tsx
+++ b/app/components/invalidate-queries.tsx
@@ -1,31 +1,17 @@
 "use client"
 
 import { useTaskHistoryWebSocket } from "@renegade-fi/react"
-import { Query, useQueryClient } from "@tanstack/react-query"
+import { useQueryClient } from "@tanstack/react-query"
+
+import { shouldInvalidate } from "@/lib/query"
 
 export function InvalidateQueries() {
   const queryClient = useQueryClient()
   useTaskHistoryWebSocket({
     onUpdate: (task) => {
       if (task.state === "Completed") {
-        // TODO: Only invalidate queries related to wallet state
-        // queryClient.invalidateQueries()
-        const nonStaticQueries = (query: Query) => {
-          const defaultStaleTime =
-            queryClient.getQueryDefaults(query.queryKey).staleTime ?? 0
-          const staleTimes = query.observers
-            .map((observer) => observer.options.staleTime ?? Infinity)
-            .filter((staleTime): staleTime is number => staleTime !== undefined)
-
-          const staleTime =
-            query.getObserversCount() > 0
-              ? Math.min(...staleTimes)
-              : defaultStaleTime
-
-          return staleTime !== Number.POSITIVE_INFINITY
-        }
         queryClient.invalidateQueries({
-          predicate: nonStaticQueries,
+          predicate: (query) => shouldInvalidate(query, queryClient),
         })
       }
     },

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -1,6 +1,34 @@
 import { Exchange, getDefaultQuoteToken, Token } from "@renegade-fi/react"
+import { Query, QueryClient } from "@tanstack/react-query"
 
 import { remapToken } from "@/lib/token"
+
+// Helper function defining a global rule for invalidating queries
+// We invalidate queries that are:
+// - Not static (finite stale time)
+// - Not a price query
+//
+// TODO: We should invalidate queries related to wallet / on-chain state
+// We apply a general global rule for now because it doesn't hurt to have fresh data.
+export function shouldInvalidate(query: Query, queryClient: QueryClient) {
+  // If the query is a price query, don't invalidate
+  if (query.queryKey.includes("price")) {
+    return false
+  }
+
+  // Invalidate if the effective stale time is not set to infinite.
+  const defaultStaleTime =
+    queryClient.getQueryDefaults(query.queryKey).staleTime ?? 0
+
+  const staleTimes = query.observers
+    .map((observer) => observer.options.staleTime ?? Infinity)
+    .filter((staleTime): staleTime is number => staleTime !== undefined)
+
+  const effectiveStaleTime =
+    query.getObserversCount() > 0 ? Math.min(...staleTimes) : defaultStaleTime
+
+  return effectiveStaleTime !== Number.POSITIVE_INFINITY
+}
 
 export async function getPriceFromPriceReporter(
   topic: string,


### PR DESCRIPTION
### Purpose
This PR prevents price query invalidation in the global invalidation rule because we depend on WebSocket messages for price data, not HTTP requests.

### Testing
- [x] Tested locally
- [ ] Test in testnet