### PR TITLE
price query: Use optimistic price status on mount

### DIFF
--- a/components/animated-price-status.tsx
+++ b/components/animated-price-status.tsx
@@ -13,10 +13,15 @@ export function AnimatedPriceStatus({
   exchange?: Exchange
   mint: `0x${string}`
 }) {
-  const { data: price, isStale } = usePriceQuery(mint, exchange)
+  const {
+    data: price,
+    isStale,
+    isFetchedAfterMount,
+  } = usePriceQuery(mint, exchange)
   const { text, statusColor } = getPriceStatus({
     price,
-    isStale,
+    // Optimistically give price a chance to update before displaying stale status
+    isStale: isFetchedAfterMount && isStale,
     mint,
     exchange,
   })


### PR DESCRIPTION
### Purpose
This PR allows prices a chance to update before displaying stale status.

### Testing
- [x] Tested locally
- [x] Test in testnet