### PR TITLE
sdk: derive config from chain id

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -115,9 +115,12 @@ export default async function RootLayout({
         >
           <ServerStoreProvider cookieString={cookieString}>
             <ClientStoreProvider>
-              <RenegadeProvider cookieString={cookieString}>
-                <SolanaProvider>
-                  <WagmiProvider initialState={initialState}>
+              <SolanaProvider>
+                <WagmiProvider initialState={initialState}>
+                  <RenegadeProvider
+                    chainId={initialState?.chainId}
+                    cookieString={cookieString}
+                  >
                     <SidebarProvider defaultOpen={defaultOpen}>
                       <TrackLastVisit />
                       <WalletSidebarSync />
@@ -150,9 +153,9 @@ export default async function RootLayout({
                       <ClearCookie />
                       <WalletSidebar side="right" />
                     </SidebarProvider>
-                  </WagmiProvider>
-                </SolanaProvider>
-              </RenegadeProvider>
+                  </RenegadeProvider>
+                </WagmiProvider>
+              </SolanaProvider>
             </ClientStoreProvider>
           </ServerStoreProvider>
         </ThemeProvider>

--- a/components/dialogs/onboarding/sign-in-dialog.tsx
+++ b/components/dialogs/onboarding/sign-in-dialog.tsx
@@ -115,6 +115,7 @@ export function SignInDialog({
   } = useMutation({
     mutationFn: async (variables: { signature: `0x${string}` }) => {
       const seed = variables.signature
+      if (!config) return
       config.setState((x) => ({ ...x, seed }))
       const id = getWalletId(config)
       config.setState((x) => ({ ...x, id }))

--- a/hooks/use-wallets.ts
+++ b/hooks/use-wallets.ts
@@ -48,7 +48,7 @@ export function useWallets() {
   const walletId = useWalletId()
 
   const renegadeWallet: Wallet =
-    config.state.seed && walletId
+    config?.state.seed && walletId
       ? {
           name: "Renegade Wallet ID",
           icon: "/glyph_light.png",
@@ -105,18 +105,20 @@ export function useWallets() {
     switch (status) {
       case "connecting":
       case "reconnecting":
-        return config.state.seed && address && connector
+        return config?.state.seed && address && connector
           ? "READY"
           : "CONNECTING"
 
       case "connected":
-        return config.state.seed && address && connector ? "READY" : "NOT_READY"
+        return config?.state.seed && address && connector
+          ? "READY"
+          : "NOT_READY"
 
       case "disconnected":
       default:
         return "NOT_READY"
     }
-  }, [address, config.state.seed, connector, status])
+  }, [address, config?.state.seed, connector, status])
 
   return {
     renegadeWallet,

--- a/providers/renegade-provider/config.ts
+++ b/providers/renegade-provider/config.ts
@@ -1,4 +1,9 @@
-import { createConfig, createStorage, getSDKConfig } from "@renegade-fi/react"
+import {
+  createConfig,
+  createStorage,
+  getSDKConfig,
+  isSupportedChainId,
+} from "@renegade-fi/react"
 
 import { env } from "@/env/client"
 import { cookieStorage } from "@/lib/cookie"
@@ -6,15 +11,18 @@ import { viemClient } from "@/lib/viem"
 
 export const sdkConfig = getSDKConfig(env.NEXT_PUBLIC_CHAIN_ID)
 
-export const config = createConfig({
-  chainId: sdkConfig.id,
-  darkPoolAddress: sdkConfig.darkpoolAddress,
-  priceReporterUrl: sdkConfig.priceReporterUrl,
-  relayerUrl: sdkConfig.relayerUrl,
-  ssr: true,
-  storage: createStorage({
-    storage: cookieStorage,
-  }),
-  // @sehyunc TODO: remove public client from config instantiation
-  viemClient: viemClient as any,
-})
+export const getConfigFromChainId = (chainId: number) => {
+  if (!isSupportedChainId(chainId)) return undefined
+  const sdkConfig = getSDKConfig(chainId)
+  return createConfig({
+    chainId,
+    darkPoolAddress: sdkConfig.darkpoolAddress,
+    priceReporterUrl: sdkConfig.priceReporterUrl,
+    relayerUrl: sdkConfig.relayerUrl,
+    ssr: true,
+    storage: createStorage({
+      storage: cookieStorage,
+    }),
+    viemClient: viemClient as any,
+  })
+}

--- a/providers/renegade-provider/renegade-provider.tsx
+++ b/providers/renegade-provider/renegade-provider.tsx
@@ -1,28 +1,151 @@
 "use client"
 
-import { RenegadeProvider as Provider } from "@renegade-fi/react"
-import { cookieToInitialState } from "@renegade-fi/react"
+import React from "react"
 
-import { config } from "./config"
+import {
+  Config,
+  cookieToInitialState,
+  RenegadeProvider as Provider,
+  useConfig,
+} from "@renegade-fi/react"
+import { disconnect } from "@renegade-fi/react/actions"
+import { ROOT_KEY_MESSAGE_PREFIX } from "@renegade-fi/react/constants"
+import { ConnectKitProvider } from "connectkit"
+import {
+  useAccount,
+  useConnect,
+  useConnections,
+  useDisconnect,
+  useReconnect,
+} from "wagmi"
+
+import { SignInDialog } from "@/components/dialogs/onboarding/sign-in-dialog"
+
+import { sidebarEvents } from "@/lib/events"
+import { chain, viemClient } from "@/lib/viem"
+
+import { getConfigFromChainId } from "./config"
 
 interface RenegadeProviderProps {
   children: React.ReactNode
   cookieString?: string
+  chainId?: number
+}
+
+const connectKitTheme = {
+  "--ck-body-background": "hsl(var(--background))",
+  "--ck-border-radius": "0",
+  "--ck-font-family": "var(--font-sans-extended)",
+  "--ck-primary-button-background": "hsl(var(--background))",
+  "--ck-primary-button-border-radius": "0",
+  "--ck-body-color": "hsl(var(--foreground))",
+  "--ck-body-color-muted": "hsl(var(--muted-foreground))",
+  "--ck-body-color-muted-hover": "hsl(var(--foreground))",
+  "--ck-qr-dot-color": "hsl(var(--chart-blue))",
+  "--ck-secondary-button-background": "hsl(var(--background))",
+  "--ck-qr-border-color": "hsl(var(--border))",
+  "--ck-overlay-background": "rgba(0,0,0,.8)",
 }
 
 export function RenegadeProvider({
   children,
   cookieString,
+  chainId,
 }: RenegadeProviderProps) {
-  const initialState = cookieToInitialState(config, cookieString)
+  const [open, setOpen] = React.useState(false)
+  const [config, setConfig] = React.useState<Config | undefined>(() => {
+    if (chainId) {
+      return getConfigFromChainId(chainId)
+    }
+    return undefined
+  })
+  const initialState = config
+    ? cookieToInitialState(config, cookieString)
+    : undefined
 
   return (
     <Provider
+      reconnectOnMount
       config={config}
       initialState={initialState}
-      reconnectOnMount
     >
-      {children}
+      <ConnectKitProvider
+        customTheme={connectKitTheme}
+        options={{
+          hideQuestionMarkCTA: true,
+          hideTooltips: true,
+          enforceSupportedChains: true,
+        }}
+        theme="midnight"
+        onConnect={() => {
+          sidebarEvents.emit("open")
+          setOpen(true)
+        }}
+      >
+        {children}
+        <SyncRenegadeWagmiState />
+        <SignInDialog
+          open={open}
+          onOpenChange={setOpen}
+        />
+      </ConnectKitProvider>
     </Provider>
   )
+}
+
+function SyncRenegadeWagmiState() {
+  const config = useConfig()
+  const { connector, chainId, isDisconnected } = useAccount()
+  const connections = useConnections()
+  const { connect: connectWagmi } = useConnect()
+  const { disconnectAsync: disconnectWagmi } = useDisconnect()
+  const { reconnectAsync: reconnectWagmi } = useReconnect()
+
+  // Handles the case where Renegade wallet is connected, but wagmi wallet is not
+  // Required because effect below does not catch locked wallet case
+  React.useEffect(() => {
+    if (isDisconnected && config?.state.seed) {
+      console.log("Wallet disconnected: wallet not connected and seed exists")
+      console.log(
+        `Wallet disconnected: found ${connections.length} connections. Attempting to reconnect.`,
+      )
+      reconnectWagmi().then((conns) => {
+        if (conns.length === 0) {
+          console.log("Wallet disconnected: failed to reconnect")
+          disconnect(config)
+        } else {
+          console.log("Wallet disconnected: successfully reconnected")
+        }
+      })
+    }
+  }, [config, connections.length, isDisconnected, reconnectWagmi])
+
+  // When switching accounts in a wallet, we need to ensure the new account
+  // is the one that originally generated the seed in storage. This effect:
+  // 1. Verifies the current account can sign the stored seed
+  // 2. Disconnects both wagmi and renegade if verification fails
+  React.useEffect(() => {
+    if (!connections.length || !config?.state.seed) return
+
+    viemClient
+      .verifyMessage({
+        address: connections[0].accounts[0],
+        message: `${ROOT_KEY_MESSAGE_PREFIX} ${chain.id}`,
+        signature: config.state.seed,
+      })
+      .then((verified) => {
+        if (!verified) {
+          console.log("Client disconnect reason: active account changed")
+          // disconnectWagmi()
+          disconnect(config)
+        }
+      })
+      .catch(() => {
+        console.log("Client disconnect reason: failed to verify signature")
+        disconnectWagmi()
+        disconnect(config)
+      })
+  }, [config, connections, disconnectWagmi])
+
+  return null
 }

--- a/providers/wagmi-provider/wagmi-provider.tsx
+++ b/providers/wagmi-provider/wagmi-provider.tsx
@@ -3,24 +3,8 @@
 import React from "react"
 
 import { EVM, createConfig as createLifiConfig } from "@lifi/sdk"
-import { useConfig } from "@renegade-fi/react"
-import { disconnect } from "@renegade-fi/react/actions"
-import { ROOT_KEY_MESSAGE_PREFIX } from "@renegade-fi/react/constants"
-import { ConnectKitProvider } from "connectkit"
-import {
-  WagmiProvider as Provider,
-  State,
-  useAccount,
-  useConnect,
-  useConnections,
-  useDisconnect,
-  useReconnect,
-} from "wagmi"
+import { WagmiProvider as Provider, State } from "wagmi"
 
-import { SignInDialog } from "@/components/dialogs/onboarding/sign-in-dialog"
-
-import { sidebarEvents } from "@/lib/events"
-import { chain, viemClient } from "@/lib/viem"
 import { QueryProvider } from "@/providers/query-provider"
 
 import { getConfig } from "./config"
@@ -32,28 +16,12 @@ createLifiConfig({
   preloadChains: false,
 })
 
-const connectKitTheme = {
-  "--ck-body-background": "hsl(var(--background))",
-  "--ck-border-radius": "0",
-  "--ck-font-family": "var(--font-sans-extended)",
-  "--ck-primary-button-background": "hsl(var(--background))",
-  "--ck-primary-button-border-radius": "0",
-  "--ck-body-color": "hsl(var(--foreground))",
-  "--ck-body-color-muted": "hsl(var(--muted-foreground))",
-  "--ck-body-color-muted-hover": "hsl(var(--foreground))",
-  "--ck-qr-dot-color": "hsl(var(--chart-blue))",
-  "--ck-secondary-button-background": "hsl(var(--background))",
-  "--ck-qr-border-color": "hsl(var(--border))",
-  "--ck-overlay-background": "rgba(0,0,0,.8)",
-}
-
 interface WagmiProviderProps {
   children: React.ReactNode
   initialState?: State
 }
 
 export function WagmiProvider({ children, initialState }: WagmiProviderProps) {
-  const [open, setOpen] = React.useState(false)
   const [config] = React.useState(() => getConfig())
 
   return (
@@ -62,85 +30,7 @@ export function WagmiProvider({ children, initialState }: WagmiProviderProps) {
       config={config}
       initialState={initialState}
     >
-      <QueryProvider>
-        <ConnectKitProvider
-          customTheme={connectKitTheme}
-          options={{
-            hideQuestionMarkCTA: true,
-            hideTooltips: true,
-            enforceSupportedChains: true,
-          }}
-          theme="midnight"
-          onConnect={() => {
-            sidebarEvents.emit("open")
-            setOpen(true)
-          }}
-        >
-          {children}
-          <SyncRenegadeWagmiState />
-          <SignInDialog
-            open={open}
-            onOpenChange={setOpen}
-          />
-        </ConnectKitProvider>
-      </QueryProvider>
+      <QueryProvider>{children}</QueryProvider>
     </Provider>
   )
-}
-
-function SyncRenegadeWagmiState() {
-  const config = useConfig()
-  const { connector, chainId, isDisconnected } = useAccount()
-  const connections = useConnections()
-  const { connect: connectWagmi } = useConnect()
-  const { disconnectAsync: disconnectWagmi } = useDisconnect()
-  const { reconnectAsync: reconnectWagmi } = useReconnect()
-
-  // Handles the case where Renegade wallet is connected, but wagmi wallet is not
-  // Required because effect below does not catch locked wallet case
-  React.useEffect(() => {
-    if (isDisconnected && config.state.seed) {
-      console.log("Wallet disconnected: wallet not connected and seed exists")
-      console.log(
-        `Wallet disconnected: found ${connections.length} connections. Attempting to reconnect.`,
-      )
-      reconnectWagmi().then((conns) => {
-        if (conns.length === 0) {
-          console.log("Wallet disconnected: failed to reconnect")
-          disconnect(config)
-        } else {
-          console.log("Wallet disconnected: successfully reconnected")
-        }
-      })
-    }
-  }, [config, connections.length, isDisconnected, reconnectWagmi])
-
-  // When switching accounts in a wallet, we need to ensure the new account
-  // is the one that originally generated the seed in storage. This effect:
-  // 1. Verifies the current account can sign the stored seed
-  // 2. Disconnects both wagmi and renegade if verification fails
-  React.useEffect(() => {
-    if (!connections.length || !config.state.seed) return
-
-    viemClient
-      .verifyMessage({
-        address: connections[0].accounts[0],
-        message: `${ROOT_KEY_MESSAGE_PREFIX} ${chain.id}`,
-        signature: config.state.seed,
-      })
-      .then((verified) => {
-        if (!verified) {
-          console.log("Client disconnect reason: active account changed")
-          // disconnectWagmi()
-          disconnect(config)
-        }
-      })
-      .catch(() => {
-        console.log("Client disconnect reason: failed to verify signature")
-        disconnectWagmi()
-        disconnect(config)
-      })
-  }, [config, config.state.seed, connections, disconnectWagmi])
-
-  return null
 }


### PR DESCRIPTION
### Purpose
This PR begins the process of migrating to configs derived from the current chain ID which is managed by wagmi instead of stored in process.env. This involves accounting for potentially undefined configs, as chain ID may be undefined. This PR will not build, as minimal changes have been made to both keep diffs manageable and de-risk this method of constructing configs.

In future PRs, we will remove usage of process.env.CHAIN_ID entirely, as well as updating all callsites to use the wagmi provided chain ID.

### Testing
- [ ] Tested locally
- [ ] Test in testnet