### PR TITLE
finish guarding undefined config

### DIFF
--- a/app/api/faucet/route.ts
+++ b/app/api/faucet/route.ts
@@ -8,7 +8,7 @@ import {
   parseUnits,
 } from "viem"
 import { privateKeyToAccount } from "viem/accounts"
-import { arbitrum, arbitrumSepolia, baseSepolia } from "viem/chains"
+import { arbitrum, arbitrumSepolia, base, baseSepolia } from "viem/chains"
 import { createConfig } from "wagmi"
 
 import { env } from "@/env/server"
@@ -30,6 +30,7 @@ const viemConfig = createConfig({
     [arbitrum.id]: http(),
     [arbitrumSepolia.id]: http(),
     [baseSepolia.id]: http(),
+    [base.id]: http(),
   },
 })
 

--- a/app/components/wallet-sidebar/arbitrum-wallet-actions-dropdown.tsx
+++ b/app/components/wallet-sidebar/arbitrum-wallet-actions-dropdown.tsx
@@ -37,7 +37,9 @@ export function ArbitrumWalletActionsDropdown({
   }
 
   const handleDisconnect = () => {
-    disconnectRenegade(config)
+    if (config) {
+      disconnectRenegade(config)
+    }
     disconnect()
   }
 

--- a/app/components/wallet-sidebar/renegade-wallet-actions-dropdown.tsx
+++ b/app/components/wallet-sidebar/renegade-wallet-actions-dropdown.tsx
@@ -30,7 +30,7 @@ export function RenegadeWalletActionsDropdown({
   const { rememberMe, setRememberMe } = useClientStore((state) => state)
 
   const handleRefreshWallet = async () => {
-    if (wallet.isConnected) {
+    if (wallet.isConnected && config) {
       await refreshWallet(config)
     }
   }
@@ -42,7 +42,9 @@ export function RenegadeWalletActionsDropdown({
   }
 
   const handleDisconnect = () => {
-    disconnectRenegade(config)
+    if (config) {
+      disconnectRenegade(config)
+    }
     disconnect()
   }
 

--- a/components/dialogs/transfer/helpers.ts
+++ b/components/dialogs/transfer/helpers.ts
@@ -132,8 +132,11 @@ export function getExplorerLink(
   return `${explorerUrl}/tx/${txHash}`
 }
 
-export function verifyRecipientAddress(config: Config, recipient?: string) {
-  invariant(config.state.seed, "Seed is required")
+export function verifyRecipientAddress(
+  seed?: `0x${string}`,
+  recipient?: string,
+) {
+  invariant(seed, "Seed is required")
   invariant(
     recipient && isAddress(recipient),
     "Recipient is required and must be a valid address",
@@ -141,6 +144,6 @@ export function verifyRecipientAddress(config: Config, recipient?: string) {
   return viemClient.verifyMessage({
     address: recipient,
     message: `${ROOT_KEY_MESSAGE_PREFIX} ${chain.id}`,
-    signature: config.state.seed,
+    signature: seed,
   })
 }

--- a/components/dialogs/transfer/usdc-form.tsx
+++ b/components/dialogs/transfer/usdc-form.tsx
@@ -616,7 +616,7 @@ export function USDCForm({
 
     if (bridgeRequired && bridgeQuote) {
       const validRecipient = await verifyRecipientAddress(
-        renegadeConfig,
+        renegadeConfig?.state.seed,
         bridgeQuote?.action.toAddress,
       )
       if (!validRecipient) {

--- a/hooks/use-cancel-all-orders.ts
+++ b/hooks/use-cancel-all-orders.ts
@@ -13,7 +13,7 @@ export function useCancelAllOrders() {
   })
 
   async function handleCancelAllOrders() {
-    if (!data) return
+    if (!data || !config) return
 
     for (const orderId of data) {
       try {

--- a/hooks/use-deposit.ts
+++ b/hooks/use-deposit.ts
@@ -34,7 +34,13 @@ export function useDeposit() {
     amount: string
     onSuccess?: ({ taskId }: { taskId: string }) => void
   }) {
-    if (!walletClient || !mint || !isAddress(mint, { strict: false })) return
+    if (
+      !walletClient ||
+      !mint ||
+      !isAddress(mint, { strict: false }) ||
+      !config
+    )
+      return
     const token = Token.findByAddress(mint as `0x${string}`)
     const parsedAmount = safeParseUnits(amount, token.decimals)
     if (parsedAmount instanceof Error) {

--- a/hooks/use-prepare-cancel-order.ts
+++ b/hooks/use-prepare-cancel-order.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  ConfigRequiredError,
   stringifyForWasm,
   useBackOfQueueWallet,
   useConfig,
@@ -20,6 +21,7 @@ export function usePrepareCancelOrder(
   return useQuery({
     queryKey: ["prepare", "cancel-order", parameters],
     queryFn: async () => {
+      if (!config) throw new ConfigRequiredError("usePrepareCancelOrder")
       if (!config.state.seed) throw new Error("Seed is required")
       if (!isSuccess) return undefined
       if (wallet.orders.find((order) => order.id === id)) {
@@ -31,6 +33,6 @@ export function usePrepareCancelOrder(
       }
       return null
     },
-    enabled: Boolean(config.state.seed),
+    enabled: Boolean(config?.state.seed),
   })
 }

--- a/hooks/use-prepare-create-order.ts
+++ b/hooks/use-prepare-create-order.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  ConfigRequiredError,
   stringifyForWasm,
   useBackOfQueueWallet,
   useConfig,
@@ -40,6 +41,7 @@ export function usePrepareCreateOrder(
   return useQuery({
     queryKey: ["prepare", "create-order", parameters],
     queryFn: async () => {
+      if (!config) throw new ConfigRequiredError("usePrepareCreateOrder")
       if (!config.state.seed) throw new Error("Seed is required")
       if (!isSuccess) throw new Error("Failed to fetch wallet.")
       if (wallet.orders.filter((order) => order.amount).length >= MAX_ORDERS)
@@ -66,6 +68,6 @@ export function usePrepareCreateOrder(
         allowExternalMatches,
       )
     },
-    enabled: isSuccess && Boolean(config.state.seed),
+    enabled: isSuccess && Boolean(config?.state.seed),
   })
 }

--- a/hooks/use-sign-in-and-connect.ts
+++ b/hooks/use-sign-in-and-connect.ts
@@ -17,7 +17,9 @@ export function useSignInAndConnect() {
   const handleClick = () => {
     if (address) {
       if (renegadeStatus === "in relayer") {
-        disconnectRenegade(config)
+        if (config) {
+          disconnectRenegade(config)
+        }
         disconnect()
       } else {
         setOpenSignIn(true)

--- a/hooks/use-withdraw.ts
+++ b/hooks/use-withdraw.ts
@@ -1,6 +1,6 @@
 import { useState } from "react"
 
-import { useConfig, usePayFees } from "@renegade-fi/react"
+import { ConfigRequiredError, useConfig, usePayFees } from "@renegade-fi/react"
 import { withdraw } from "@renegade-fi/react/actions"
 import { Token } from "@renegade-fi/token-nextjs"
 import { MutationStatus } from "@tanstack/react-query"
@@ -28,6 +28,7 @@ export function useWithdraw({
   }: {
     onSuccess?: ({ taskId }: { taskId: string }) => void
   }) => {
+    if (!config) throw new ConfigRequiredError("useWithdraw")
     if (!address || !mint || !isAddress(mint, { strict: false })) return
     const token = Token.findByAddress(mint as `0x${string}`)
     const parsedAmount = safeParseUnits(amount, token.decimals)

--- a/hooks/usePrepareDeposit.ts
+++ b/hooks/usePrepareDeposit.ts
@@ -3,6 +3,7 @@
 import React from "react"
 
 import {
+  ConfigRequiredError,
   stringifyForWasm,
   useBackOfQueueWallet,
   useConfig,
@@ -29,6 +30,7 @@ export function usePrepareDeposit(parameters: UsePrepareDepositParameters) {
   const config = useConfig()
   const { data: wallet, isSuccess } = useBackOfQueueWallet()
   const request = React.useMemo(() => {
+    if (!config) throw new ConfigRequiredError("usePrepareDeposit")
     if (!isSuccess) return undefined
     if (
       !amount ||

--- a/hooks/usePrepareWithdraw.ts
+++ b/hooks/usePrepareWithdraw.ts
@@ -3,6 +3,7 @@
 import React from "react"
 
 import {
+  ConfigRequiredError,
   stringifyForWasm,
   useBackOfQueueWallet,
   useConfig,
@@ -32,6 +33,7 @@ export function usePrepareWithdraw(
   const { data: wallet, isSuccess } = useBackOfQueueWallet()
 
   const request = React.useMemo(() => {
+    if (!config) throw new ConfigRequiredError("usePrepareWithdraw")
     if (!isSuccess || !mint || !amount || !destinationAddr || !enabled)
       return undefined
     if (!isAddress(mint) || !isAddress(destinationAddr)) return undefined

--- a/lib/viem.ts
+++ b/lib/viem.ts
@@ -11,7 +11,7 @@ import {
 import { env } from "@/env/client"
 
 export const chain = extractChain({
-  chains: [arbitrum, arbitrumSepolia, baseSepolia],
+  chains: [arbitrum, arbitrumSepolia, baseSepolia, base],
   id: env.NEXT_PUBLIC_CHAIN_ID,
 })
 

--- a/providers/renegade-provider/renegade-provider.tsx
+++ b/providers/renegade-provider/renegade-provider.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React from "react"
+import React, { useMemo } from "react"
 
 import {
   Config,
@@ -53,12 +53,12 @@ export function RenegadeProvider({
   chainId,
 }: RenegadeProviderProps) {
   const [open, setOpen] = React.useState(false)
-  const [config, setConfig] = React.useState<Config | undefined>(() => {
+  const config = useMemo(() => {
     if (chainId) {
       return getConfigFromChainId(chainId)
     }
     return undefined
-  })
+  }, [chainId])
   const initialState = config
     ? cookieToInitialState(config, cookieString)
     : undefined

--- a/providers/wagmi-provider/config.ts
+++ b/providers/wagmi-provider/config.ts
@@ -1,5 +1,11 @@
 import { http } from "viem"
-import { mainnet, arbitrum, arbitrumSepolia, baseSepolia } from "viem/chains"
+import {
+  mainnet,
+  arbitrum,
+  arbitrumSepolia,
+  baseSepolia,
+  base,
+} from "viem/chains"
 import { createConfig, createStorage, cookieStorage } from "wagmi"
 
 import { env } from "@/env/client"
@@ -45,6 +51,7 @@ export const arbitrumConfig = createConfig({
     [arbitrum.id]: http(),
     [arbitrumSepolia.id]: http(),
     [baseSepolia.id]: http(),
+    [base.id]: http(),
   },
 })
 


### PR DESCRIPTION
### Purpose
This PR ensures the client environment is aware that configs may now be undefined. Worth noting that this is mostly to appease the Typescript compiler: most of these branches are impossible to reach if the config is undefined. Ideally we make Typescript aware of this using type narrowing on the config object itself, but this is sufficient for a straightforward and simple implementation.

### Testing
- [ ] Tested locally
- [ ] Test in testnet