### PR TITLE
begin removing chain id env var: use sdk config

### DIFF
--- a/app/api/get-logs/route.ts
+++ b/app/api/get-logs/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest } from "next/server"
 
-import { encodeEventTopics, numberToHex, parseAbiItem, toHex } from "viem"
+import { getSDKConfig } from "@renegade-fi/react"
+import { encodeEventTopics, parseAbiItem, toHex } from "viem"
 
 import { env } from "@/env/server"
-import { sdkConfig } from "@/providers/renegade-provider/config"
 
 export const runtime = "edge"
 
@@ -14,6 +14,10 @@ export async function GET(req: NextRequest) {
     )
     if (!blinderShare) {
       throw new Error("Blinder share is required")
+    }
+    const chainId = Number(req.nextUrl.searchParams.get("chainId"))
+    if (!chainId) {
+      throw new Error("Chain ID is required")
     }
 
     const topics = encodeEventTopics({
@@ -37,7 +41,7 @@ export async function GET(req: NextRequest) {
         method: "eth_getLogs",
         params: [
           {
-            address: sdkConfig.darkpoolAddress,
+            address: getSDKConfig(chainId).darkpoolAddress,
             topics,
             fromBlock: toHex(env.ARBITRUM_DEPLOY_BLOCK),
           },

--- a/app/api/stats/set-inflow-kv/route.ts
+++ b/app/api/stats/set-inflow-kv/route.ts
@@ -4,26 +4,25 @@ import { Token } from "@renegade-fi/token-nextjs"
 import { kv } from "@vercel/kv"
 import {
   createPublicClient,
-  http,
-  parseAbiItem,
-  isAddress,
   formatUnits,
+  http,
+  isAddress,
+  parseAbiItem,
 } from "viem"
 
 import { fetchAssetPrice } from "@/app/api/amberdata/helpers"
 import {
   BLOCK_CHUNK_SIZE,
-  LAST_PROCESSED_BLOCK_KEY,
-  INFLOWS_KEY,
   ExternalTransferData,
+  INFLOWS_KEY,
   INFLOWS_SET_KEY,
+  LAST_PROCESSED_BLOCK_KEY,
 } from "@/app/api/stats/constants"
 
 import { env } from "@/env/server"
 import { amountTimesPrice } from "@/hooks/use-usd-price"
 import { DISPLAY_TOKENS, remapToken } from "@/lib/token"
-import { chain } from "@/lib/viem"
-import { sdkConfig } from "@/providers/renegade-provider/config"
+import { arbitrumSDKConfig, chain } from "@/lib/viem"
 
 const viemClient = createPublicClient({
   chain,
@@ -76,7 +75,8 @@ export async function GET(req: NextRequest) {
     // Get all external transfer logs
     console.log("Fetching external transfer logs")
     const logs = await viemClient.getLogs({
-      address: sdkConfig.darkpoolAddress,
+      // @sehyunc TODO: remove hardcoded chain id
+      address: arbitrumSDKConfig.darkpoolAddress,
       event: parseAbiItem(
         "event ExternalTransfer(address indexed account, address indexed mint, bool indexed is_withdrawal, uint256 amount)",
       ),

--- a/app/api/stats/tvl/route.ts
+++ b/app/api/stats/tvl/route.ts
@@ -2,7 +2,7 @@ import { encodeFunctionData, hexToBigInt, parseAbi } from "viem"
 
 import { env } from "@/env/server"
 import { DISPLAY_TOKENS } from "@/lib/token"
-import { sdkConfig } from "@/providers/renegade-provider/config"
+import { arbitrumSDKConfig } from "@/lib/viem"
 
 export const runtime = "edge"
 
@@ -16,7 +16,7 @@ export async function GET() {
           const tvl = await fetchTvl(
             token.address,
             env.RPC_URL,
-            sdkConfig.darkpoolAddress,
+            arbitrumSDKConfig.darkpoolAddress,
           )
           return { ticker: token.ticker, tvl: tvl.toString() }
         } catch (error) {

--- a/app/api/stats/tvl/usd/route.ts
+++ b/app/api/stats/tvl/usd/route.ts
@@ -5,7 +5,7 @@ import { fetchAssetPrice } from "@/app/api/amberdata/helpers"
 
 import { env } from "@/env/server"
 import { DISPLAY_TOKENS, remapToken } from "@/lib/token"
-import { sdkConfig } from "@/providers/renegade-provider/config"
+import { arbitrumSDKConfig } from "@/lib/viem"
 
 export const runtime = "edge"
 
@@ -18,7 +18,11 @@ export async function GET() {
       tokens.map(async (token) => {
         try {
           const [balance, price] = await Promise.all([
-            fetchTvl(token.address, env.RPC_URL, sdkConfig.darkpoolAddress),
+            fetchTvl(
+              token.address,
+              env.RPC_URL,
+              arbitrumSDKConfig.darkpoolAddress,
+            ),
             fetchAssetPrice(remapToken(token.ticker), env.AMBERDATA_API_KEY),
           ])
           return {

--- a/components/dialogs/onboarding/sign-in-dialog.tsx
+++ b/components/dialogs/onboarding/sign-in-dialog.tsx
@@ -116,7 +116,7 @@ export function SignInDialog({
     mutationFn: async (variables: { signature: `0x${string}` }) => {
       const seed = variables.signature
       if (!config) return
-      config.setState((x) => ({ ...x, seed }))
+      config.setState((x) => ({ ...x, seed, chainId: currentChainId }))
       const id = getWalletId(config)
       config.setState((x) => ({ ...x, id }))
 
@@ -132,7 +132,9 @@ export function SignInDialog({
 
       // GET # logs
       const blinderShare = config.utils.derive_blinder_share(seed)
-      const res = await fetch(`/api/get-logs?blinderShare=${blinderShare}`)
+      const res = await fetch(
+        `/api/get-logs?blinderShare=${blinderShare}&chainId=${currentChainId}`,
+      )
       if (!res.ok) throw new Error("Failed to query chain")
       const { logs } = await res.json()
       // Iff logs === 0, create wallet

--- a/components/dialogs/transfer/usdc-form.tsx
+++ b/components/dialogs/transfer/usdc-form.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden"
-import { UpdateType, useConfig } from "@renegade-fi/react"
+import { UpdateType, getSDKConfig, useConfig } from "@renegade-fi/react"
 import { Token } from "@renegade-fi/token-nextjs"
 import { useQueryClient } from "@tanstack/react-query"
 import { AlertCircle, Check, Loader2 } from "lucide-react"
@@ -82,7 +82,6 @@ import { useReadErc20Allowance, useWriteErc20Approve } from "@/lib/generated"
 import { ADDITIONAL_TOKENS, ETHEREUM_TOKENS, SOLANA_TOKENS } from "@/lib/token"
 import { cn } from "@/lib/utils"
 import { chain, getFormattedChainName, solana } from "@/lib/viem"
-import { sdkConfig } from "@/providers/renegade-provider/config"
 import { useServerStore } from "@/providers/state-provider/server-store-provider"
 import { mainnetConfig } from "@/providers/wagmi-provider/config"
 
@@ -124,6 +123,7 @@ export function USDCForm({
     },
   })
   const renegadeConfig = useConfig()
+  const chainId = renegadeConfig?.state.chainId
 
   const catchError = (error: Error, message: string) => {
     console.error("Error in USDC form", error)
@@ -336,7 +336,10 @@ export function USDCForm({
         await switchChainAndInvoke(chain.id, () =>
           handleApprove({
             address: USDC_L2_TOKEN.address,
-            args: [sdkConfig.permit2Address, UNLIMITED_ALLOWANCE],
+            args: [
+              chainId ? getSDKConfig(chainId).permit2Address : "0x",
+              UNLIMITED_ALLOWANCE,
+            ],
           }),
         )
       } else {
@@ -387,7 +390,10 @@ export function USDCForm({
         await switchChainAndInvoke(chain.id, () =>
           handleApprove({
             address: USDC_L2_TOKEN.address,
-            args: [sdkConfig.permit2Address, UNLIMITED_ALLOWANCE],
+            args: [
+              chainId ? getSDKConfig(chainId).permit2Address : "0x",
+              UNLIMITED_ALLOWANCE,
+            ],
           }),
         )
       } else {
@@ -486,7 +492,10 @@ export function USDCForm({
       await switchChainAndInvoke(chain.id, () =>
         handleApprove({
           address: USDC_L2_TOKEN.address,
-          args: [sdkConfig.permit2Address, UNLIMITED_ALLOWANCE],
+          args: [
+            chainId ? getSDKConfig(chainId).permit2Address : "0x",
+            UNLIMITED_ALLOWANCE,
+          ],
         }),
       )
     } else {
@@ -508,7 +517,10 @@ export function USDCForm({
   const { data: allowanceRequired, queryKey: usdcL2AllowanceQueryKey } =
     useReadErc20Allowance({
       address: USDC_L2_TOKEN.address,
-      args: [address ?? "0x", sdkConfig.permit2Address],
+      args: [
+        address ?? "0x",
+        chainId ? getSDKConfig(chainId).permit2Address : "0x",
+      ],
       chainId: chain.id,
       query: {
         select: (data) => {
@@ -725,7 +737,10 @@ export function USDCForm({
       await switchChainAndInvoke(chain.id, () =>
         handleApprove({
           address: USDC_L2_TOKEN.address,
-          args: [sdkConfig.permit2Address, UNLIMITED_ALLOWANCE],
+          args: [
+            chainId ? getSDKConfig(chainId).permit2Address : "0x",
+            UNLIMITED_ALLOWANCE,
+          ],
         }),
       )
     } else {

--- a/components/dialogs/transfer/weth-form.tsx
+++ b/components/dialogs/transfer/weth-form.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { usePathname, useRouter } from "next/navigation"
 
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden"
-import { UpdateType } from "@renegade-fi/react"
+import { getSDKConfig, UpdateType, useConfig } from "@renegade-fi/react"
 import { Token } from "@renegade-fi/token-nextjs"
 import { useQueryClient } from "@tanstack/react-query"
 import { AlertCircle, Check, Loader2 } from "lucide-react"
@@ -90,7 +90,6 @@ import {
 } from "@/lib/generated"
 import { ETHEREUM_TOKENS } from "@/lib/token"
 import { cn } from "@/lib/utils"
-import { sdkConfig } from "@/providers/renegade-provider/config"
 import { useServerStore } from "@/providers/state-provider/server-store-provider"
 import {
   arbitrumConfig,
@@ -113,6 +112,7 @@ export function WETHForm({
   form: UseFormReturn<z.infer<typeof formSchema>>
   header: React.ReactNode
 }) {
+  const chainId = useConfig()?.state.chainId
   const { address } = useAccount()
   const { checkChain } = useCheckChain()
   const isMaxBalances = useIsMaxBalances(WETH_L2_TOKEN.address)
@@ -243,7 +243,10 @@ export function WETHForm({
       if (allowanceRequired) {
         handleApprove({
           address: WETH_L2_TOKEN.address,
-          args: [sdkConfig.permit2Address, UNLIMITED_ALLOWANCE],
+          args: [
+            chainId ? getSDKConfig(chainId).permit2Address : "0x",
+            UNLIMITED_ALLOWANCE,
+          ],
         })
       } else {
         handleDeposit({
@@ -260,7 +263,7 @@ export function WETHForm({
     useAllowanceRequired({
       amount: amount.toString(),
       mint,
-      spender: sdkConfig.permit2Address,
+      spender: chainId ? getSDKConfig(chainId).permit2Address : undefined,
       decimals: WETH_L2_TOKEN.decimals,
     })
 
@@ -405,7 +408,10 @@ export function WETHForm({
       } else if (allowanceRequired) {
         handleApprove({
           address: WETH_L2_TOKEN.address,
-          args: [sdkConfig.permit2Address, UNLIMITED_ALLOWANCE],
+          args: [
+            chainId ? getSDKConfig(chainId).permit2Address : "0x",
+            UNLIMITED_ALLOWANCE,
+          ],
         })
       } else {
         handleDeposit({

--- a/hooks/use-chain.ts
+++ b/hooks/use-chain.ts
@@ -1,0 +1,14 @@
+import { useConfig } from "@renegade-fi/react"
+import { type Chain } from "viem"
+
+import { extractSupportedChain } from "@/lib/viem"
+
+/**
+ * @returns The Viem `Chain` object of the chain the user signed in with.
+ * This may be different from the chain the user's browser wallet is connected to.
+ */
+export function useChain(): Chain | undefined {
+  const config = useConfig()
+  if (!config?.state.chainId) return undefined
+  return extractSupportedChain(config.state.chainId)
+}

--- a/hooks/use-deposit.ts
+++ b/hooks/use-deposit.ts
@@ -1,6 +1,10 @@
 import React from "react"
 
-import { useBackOfQueueWallet, useConfig } from "@renegade-fi/react"
+import {
+  getSDKConfig,
+  useBackOfQueueWallet,
+  useConfig,
+} from "@renegade-fi/react"
 import { deposit, getPkRootScalars } from "@renegade-fi/react/actions"
 import { Token } from "@renegade-fi/token-nextjs"
 import { MutationStatus } from "@tanstack/react-query"
@@ -12,7 +16,6 @@ import { FAILED_DEPOSIT_MSG } from "@/lib/constants/task"
 import { safeParseUnits } from "@/lib/format"
 import { signPermit2 } from "@/lib/permit2"
 import { chain } from "@/lib/viem"
-import { sdkConfig } from "@/providers/renegade-provider/config"
 
 export function useDeposit() {
   const config = useConfig()
@@ -56,8 +59,8 @@ export function useDeposit() {
     const { signature, nonce, deadline } = await signPermit2({
       amount: parsedAmount,
       chainId: chain.id,
-      spender: sdkConfig.darkpoolAddress,
-      permit2Address: sdkConfig.permit2Address,
+      spender: getSDKConfig(config.state.chainId!).darkpoolAddress,
+      permit2Address: getSDKConfig(config.state.chainId!).permit2Address,
       token,
       walletClient,
       pkRoot,

--- a/lib/viem.ts
+++ b/lib/viem.ts
@@ -1,4 +1,4 @@
-import { chainIdToEnv } from "@renegade-fi/react"
+import { chainIdToEnv, getSDKConfig } from "@renegade-fi/react"
 import { createPublicClient, defineChain, extractChain, http } from "viem"
 import {
   arbitrumSepolia,
@@ -86,3 +86,6 @@ export function getChainLogoTicker(chainId: number): string {
       return _chain.nativeCurrency.symbol
   }
 }
+
+// TODO: Remove this once stats are recorded for all chains
+export const arbitrumSDKConfig = getSDKConfig(arbitrum.id)

--- a/providers/renegade-provider/config.ts
+++ b/providers/renegade-provider/config.ts
@@ -5,11 +5,8 @@ import {
   isSupportedChainId,
 } from "@renegade-fi/react"
 
-import { env } from "@/env/client"
 import { cookieStorage } from "@/lib/cookie"
 import { viemClient } from "@/lib/viem"
-
-export const sdkConfig = getSDKConfig(env.NEXT_PUBLIC_CHAIN_ID)
 
 export const getConfigFromChainId = (chainId: number) => {
   if (!isSupportedChainId(chainId)) return undefined


### PR DESCRIPTION
### Purpose
This PR begins the process of obviating the chain ID from environment variables. This first phase focuses on static parameters derived from the chain ID such as the Permit2 contract address.

This relies on https://github.com/renegade-fi/typescript-sdk/pull/212

### Testing
- [ ] Tested locally
- [ ] Test in testnet