### PR TITLE
persistence: begin migration to server store

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -117,10 +117,7 @@ export default async function RootLayout({
             <ClientStoreProvider>
               <SolanaProvider>
                 <WagmiProvider initialState={initialState}>
-                  <RenegadeProvider
-                    chainId={initialState?.chainId}
-                    cookieString={cookieString}
-                  >
+                  <RenegadeProvider>
                     <SidebarProvider defaultOpen={defaultOpen}>
                       <TrackLastVisit />
                       <WalletSidebarSync />

--- a/components/dialogs/onboarding/sign-in-dialog.tsx
+++ b/components/dialogs/onboarding/sign-in-dialog.tsx
@@ -3,6 +3,7 @@ import React from "react"
 import { isSupportedChainId } from "@renegade-fi/react"
 import {
   createWallet,
+  getWalletFromRelayer,
   getWalletId,
   lookupWallet,
 } from "@renegade-fi/react/actions"
@@ -121,6 +122,16 @@ export function SignInDialog({
         currentChainId,
         id,
       })
+
+      try {
+        // GET wallet from relayer
+        const wallet = await getWalletFromRelayer(config)
+        // If success, return
+        if (wallet) {
+          config.setState((x) => ({ ...x, status: "in relayer" }))
+          return ConnectSuccess.ALREADY_INDEXED
+        }
+      } catch (error) {}
 
       // GET # logs
       const blinderShare = config.utils.derive_blinder_share(seed)

--- a/components/dialogs/onboarding/sign-in-dialog.tsx
+++ b/components/dialogs/onboarding/sign-in-dialog.tsx
@@ -1,24 +1,18 @@
 import React from "react"
 
-import { useConfig } from "@renegade-fi/react"
+import { isSupportedChainId } from "@renegade-fi/react"
 import {
   createWallet,
-  getWalletFromRelayer,
   getWalletId,
   lookupWallet,
 } from "@renegade-fi/react/actions"
-import { ROOT_KEY_MESSAGE_PREFIX } from "@renegade-fi/react/constants"
+import { ChainId, ROOT_KEY_MESSAGE_PREFIX } from "@renegade-fi/react/constants"
 import { MutationStatus, useMutation } from "@tanstack/react-query"
 import { useModal } from "connectkit"
 import { Check, Loader2, X } from "lucide-react"
 import { toast } from "sonner"
 import { BaseError } from "viem"
-import {
-  useChainId,
-  useDisconnect,
-  useSignMessage,
-  useSwitchChain,
-} from "wagmi"
+import { useChainId, useDisconnect, useSignMessage } from "wagmi"
 
 import {
   ConnectSuccess,
@@ -47,7 +41,9 @@ import {
 } from "@/lib/constants/toast"
 import { sidebarEvents } from "@/lib/events"
 import { cn } from "@/lib/utils"
+import { getConfigFromChainId } from "@/providers/renegade-provider/config"
 import { useClientStore } from "@/providers/state-provider/client-store-provider.tsx"
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
 
 export function SignInDialog({
   open,
@@ -57,15 +53,14 @@ export function SignInDialog({
   onOpenChange: (open: boolean) => void
 }) {
   const currentChainId = useChainId()
-  const { switchChainAsync } = useSwitchChain()
   const { disconnectAsync } = useDisconnect()
   const isDesktop = useMediaQuery("(min-width: 1024px)")
-  const config = useConfig()
   const [connectLabel, setConnectLabel] = React.useState("Connect to relayer")
   const [currentStep, setCurrentStep] = React.useState<number | undefined>(
     undefined,
   )
   const { setOpen } = useModal()
+  const setWallet = useServerStore((state) => state.setWallet)
 
   const {
     data: signMessage1Data,
@@ -114,20 +109,18 @@ export function SignInDialog({
   } = useMutation({
     mutationFn: async (variables: { signature: `0x${string}` }) => {
       const seed = variables.signature
-      if (!config) return
-      config.setState((x) => ({ ...x, seed, chainId: currentChainId }))
+      if (!isSupportedChainId(currentChainId)) {
+        throw new Error("Unsupported chain")
+      }
+      const config = getConfigFromChainId(currentChainId)
+      config.setState((x) => ({ ...x, seed, status: "in relayer" }))
       const id = getWalletId(config)
-      config.setState((x) => ({ ...x, id }))
-
-      try {
-        // GET wallet from relayer
-        const wallet = await getWalletFromRelayer(config)
-        // If success, return
-        if (wallet) {
-          config.setState((x) => ({ ...x, status: "in relayer" }))
-          return ConnectSuccess.ALREADY_INDEXED
-        }
-      } catch (error) {}
+      setWallet(seed, currentChainId as ChainId, id)
+      console.log("setWallet debug: ", {
+        seed,
+        currentChainId,
+        id,
+      })
 
       // GET # logs
       const blinderShare = config.utils.derive_blinder_share(seed)

--- a/components/dialogs/transfer/use-bridge-quote.ts
+++ b/components/dialogs/transfer/use-bridge-quote.ts
@@ -2,10 +2,11 @@ import { QuoteRequest, getQuote } from "@lifi/sdk"
 import { Token } from "@renegade-fi/token-nextjs"
 import { useWallet as useSolanaWallet } from "@solana/wallet-adapter-react"
 import { useQuery } from "@tanstack/react-query"
-import { useAccount } from "wagmi"
+import { mainnet } from "viem/chains"
+import { useAccount, useConfig } from "wagmi"
 
 import { safeParseUnits } from "@/lib/format"
-import { evmChains, solana } from "@/lib/viem"
+import { solana } from "@/lib/viem"
 
 export interface UseBridgeParams {
   fromChain?: number
@@ -55,6 +56,8 @@ function useParams({
   fromChain,
   toChain,
 }: UseBridgeParams): QuoteRequest | undefined {
+  const config = useConfig()
+  const evmChains = [mainnet, ...config.chains]
   const { address } = useAccount()
   const { publicKey: solanaWallet } = useSolanaWallet()
   const fromAddress = evmChains.some((chain) => chain.id === fromChain)

--- a/hooks/use-in-relayer.ts
+++ b/hooks/use-in-relayer.ts
@@ -1,6 +1,0 @@
-import { useBackOfQueueWallet } from "@renegade-fi/react"
-
-export function useInRelayer() {
-  const { data, status } = useBackOfQueueWallet()
-  return Boolean(status === "success" && data.id)
-}

--- a/hooks/use-renegade-status.ts
+++ b/hooks/use-renegade-status.ts
@@ -1,0 +1,9 @@
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
+
+/**
+ * @returns true if Renegade wallet seed has been generated
+ */
+export function useRenegadeStatus() {
+  const { seed, chainId, id } = useServerStore((state) => state.wallet)
+  return { isConnected: seed && chainId && id }
+}

--- a/hooks/use-sign-in-and-connect.ts
+++ b/hooks/use-sign-in-and-connect.ts
@@ -1,22 +1,23 @@
 import { useState } from "react"
 
-import { useConfig, useStatus } from "@renegade-fi/react"
+import { useConfig } from "@renegade-fi/react"
 import { disconnect as disconnectRenegade } from "@renegade-fi/react/actions"
 import { useModal } from "connectkit"
 import { useAccount, useDisconnect } from "wagmi"
 
+import { useRenegadeStatus } from "./use-renegade-status"
+
 export function useSignInAndConnect() {
   const { address } = useAccount()
   const config = useConfig()
+  const { isConnected } = useRenegadeStatus()
   const { disconnect } = useDisconnect()
   const { setOpen } = useModal()
   const [open, setOpenSignIn] = useState(false)
 
-  const renegadeStatus = useStatus()
-
   const handleClick = () => {
     if (address) {
-      if (renegadeStatus === "in relayer") {
+      if (isConnected) {
         if (config) {
           disconnectRenegade(config)
         }
@@ -31,7 +32,7 @@ export function useSignInAndConnect() {
 
   let content = ""
   if (address) {
-    if (renegadeStatus === "in relayer") {
+    if (isConnected) {
       content = `Disconnect ${address?.slice(0, 6)}`
     } else {
       content = `Sign in`

--- a/hooks/use-wallets.ts
+++ b/hooks/use-wallets.ts
@@ -1,10 +1,11 @@
 import React from "react"
 
-import { useConfig, useWalletId } from "@renegade-fi/react"
+import { useWalletId } from "@renegade-fi/react"
 import { useWallet } from "@solana/wallet-adapter-react"
 import { useAccount, useEnsName } from "wagmi"
 
 import { truncateAddress } from "@/lib/format"
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
 import { mainnetConfig } from "@/providers/wagmi-provider/config"
 
 export interface ConnectedWallet {
@@ -44,16 +45,15 @@ export function useWallets() {
 
   // Renegade
   // Using config.state.seed && walletId because initialState loads these from cookies
-  const config = useConfig()
-  const walletId = useWalletId()
+  const { seed, id } = useServerStore((state) => state.wallet)
 
   const renegadeWallet: Wallet =
-    config?.state.seed && walletId
+    seed && id
       ? {
           name: "Renegade Wallet ID",
           icon: "/glyph_light.png",
-          id: walletId,
-          label: truncateAddress(walletId),
+          id,
+          label: truncateAddress(id),
           isConnected: true,
         }
       : {
@@ -105,20 +105,16 @@ export function useWallets() {
     switch (status) {
       case "connecting":
       case "reconnecting":
-        return config?.state.seed && address && connector
-          ? "READY"
-          : "CONNECTING"
+        return seed && address && connector ? "READY" : "CONNECTING"
 
       case "connected":
-        return config?.state.seed && address && connector
-          ? "READY"
-          : "NOT_READY"
+        return seed && address && connector ? "READY" : "NOT_READY"
 
       case "disconnected":
       default:
         return "NOT_READY"
     }
-  }, [address, config?.state.seed, connector, status])
+  }, [address, seed, connector, status])
 
   return {
     renegadeWallet,

--- a/lib/viem.ts
+++ b/lib/viem.ts
@@ -10,8 +10,6 @@ import {
 
 import { env } from "@/env/client"
 
-export const evmChains = [arbitrum, arbitrumSepolia, baseSepolia, base]
-
 export const isTestnet = env.NEXT_PUBLIC_CHAIN_ENVIRONMENT === "testnet"
 
 export const solana = defineChain({

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@radix-ui/react-visually-hidden": "^1.1.0",
     "@renegade-fi/internal-sdk": "0.4.12",
     "@renegade-fi/price-reporter": "0.0.0-canary-20250529193905",
-    "@renegade-fi/react": "0.0.0-canary-20250529181626",
+    "@renegade-fi/react": "file:/Users/s/code/sdk/packages/react",
     "@renegade-fi/token-nextjs": "^0.1.4",
     "@renegade-fi/tradingview-charts": "0.27.6",
     "@solana/wallet-adapter-base": "^0.9.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: 0.0.0-canary-20250529193905
         version: 0.0.0-canary-20250529193905(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@renegade-fi/react':
-        specifier: 0.0.0-canary-20250529181626
-        version: 0.0.0-canary-20250529181626(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+        specifier: file:/Users/s/code/sdk/packages/react
+        version: file:../sdk/packages/react(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@renegade-fi/token-nextjs':
         specifier: ^0.1.4
         version: 0.1.4(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
@@ -2836,15 +2836,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@renegade-fi/core@0.0.0-canary-20250529181626':
-    resolution: {integrity: sha512-HV40nrDSveJU8IKe7uEf+SPSI+ipu9icaqTDNR+mTvrAbZ2mr5r1nF2v3P9UgCPIOVExwI+a5VN/LD3vqTnf4g==}
-    peerDependencies:
-      '@tanstack/query-core': '>=5.0.0'
-      viem: 2.23.11
-    peerDependenciesMeta:
-      '@tanstack/query-core':
-        optional: true
-
   '@renegade-fi/core@0.0.0-canary-20250529193905':
     resolution: {integrity: sha512-hncvU/LyQVuHm6h5Z+fCTID/iiDIAehJygtniMkG5l7SY7QMJnPQK6q0muQUOrS8ZoFPkYFPCwWyE/25om7vtw==}
     peerDependencies:
@@ -2872,6 +2863,15 @@ packages:
       '@tanstack/query-core':
         optional: true
 
+  '@renegade-fi/core@file:../sdk/packages/core':
+    resolution: {directory: ../sdk/packages/core, type: directory}
+    peerDependencies:
+      '@tanstack/query-core': '>=5.0.0'
+      viem: 2.23.11
+    peerDependenciesMeta:
+      '@tanstack/query-core':
+        optional: true
+
   '@renegade-fi/internal-sdk@0.4.12':
     resolution: {integrity: sha512-/OK3Qfi5Pa62zWZ3X75R0i7jake2yqC0/hqjioD7LoC0BKok0VntOE2IBfHR+1rX31wpdfsrD+UjtOZ+MoaUAg==}
 
@@ -2881,8 +2881,8 @@ packages:
   '@renegade-fi/price-reporter@0.0.16':
     resolution: {integrity: sha512-sHWicMf2mIX3+uWl8qS5y10+BeRWTixiZtNwxav/UpP84bH8v7cZggjRIEJYzgVDW+N8UoSRo2xnN0OAo5FZFg==}
 
-  '@renegade-fi/react@0.0.0-canary-20250529181626':
-    resolution: {integrity: sha512-p0Ifvb/LweXlWFdsLY1ioyihZRiy9QRD1crQ2BecNLTFlWCvWsBwCVvBWg/tx52MRdO4yXoeOMG1rP+TZmj4hw==}
+  '@renegade-fi/react@file:../sdk/packages/react':
+    resolution: {directory: ../sdk/packages/react, type: directory}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
@@ -11385,24 +11385,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.4
 
-  '@renegade-fi/core@0.0.0-canary-20250529181626(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
-    dependencies:
-      axios: 1.7.5
-      isows: 1.0.6(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      json-bigint: 1.0.0
-      neverthrow: 8.2.0
-      tiny-invariant: 1.3.3
-      viem: 2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28)
-      zustand: 4.5.5(@types/react@19.1.4)(react@19.1.0)
-    optionalDependencies:
-      '@tanstack/query-core': 5.45.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - debug
-      - immer
-      - react
-      - ws
-
   '@renegade-fi/core@0.0.0-canary-20250529193905(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       axios: 1.7.5
@@ -11440,6 +11422,24 @@ snapshots:
       - ws
 
   '@renegade-fi/core@0.9.3(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+    dependencies:
+      axios: 1.7.5
+      isows: 1.0.6(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      json-bigint: 1.0.0
+      neverthrow: 8.2.0
+      tiny-invariant: 1.3.3
+      viem: 2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28)
+      zustand: 4.5.5(@types/react@19.1.4)(react@19.1.0)
+    optionalDependencies:
+      '@tanstack/query-core': 5.45.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - debug
+      - immer
+      - react
+      - ws
+
+  '@renegade-fi/core@file:../sdk/packages/core(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       axios: 1.7.5
       isows: 1.0.6(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
@@ -11516,9 +11516,9 @@ snapshots:
       - viem
       - ws
 
-  '@renegade-fi/react@0.0.0-canary-20250529181626(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@renegade-fi/react@file:../sdk/packages/react(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
-      '@renegade-fi/core': 0.0.0-canary-20250529181626(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@renegade-fi/core': file:../sdk/packages/core(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@tanstack/react-query': 5.45.1(react@19.1.0)
       json-bigint: 1.0.0
       react: 19.1.0

--- a/providers/renegade-provider/config.ts
+++ b/providers/renegade-provider/config.ts
@@ -1,23 +1,12 @@
-import {
-  createConfig,
-  createStorage,
-  getSDKConfig,
-  isSupportedChainId,
-} from "@renegade-fi/react"
+import { createConfig, getSDKConfig } from "@renegade-fi/react"
+import { ChainId } from "@renegade-fi/react/constants"
 
-import { cookieStorage } from "@/lib/cookie"
-
-export const getConfigFromChainId = (chainId: number) => {
-  if (!isSupportedChainId(chainId)) return undefined
+export const getConfigFromChainId = (chainId: ChainId) => {
   const sdkConfig = getSDKConfig(chainId)
   return createConfig({
     chainId,
     darkPoolAddress: sdkConfig.darkpoolAddress,
     priceReporterUrl: sdkConfig.priceReporterUrl,
     relayerUrl: sdkConfig.relayerUrl,
-    ssr: true,
-    storage: createStorage({
-      storage: cookieStorage,
-    }),
   })
 }

--- a/providers/state-provider/cookie-actions.ts
+++ b/providers/state-provider/cookie-actions.ts
@@ -6,7 +6,7 @@ export async function setCookie(name: string, value: string): Promise<void> {
   const cookieStore = await cookies()
   cookieStore.set(name, value, {
     secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
+    sameSite: "strict",
     path: "/",
   })
 }

--- a/providers/state-provider/server-store.ts
+++ b/providers/state-provider/server-store.ts
@@ -1,3 +1,4 @@
+import { ChainId } from "@renegade-fi/react/constants"
 import { createJSONStorage, persist } from "zustand/middleware"
 import { createStore } from "zustand/vanilla"
 
@@ -7,6 +8,11 @@ import { createCookieStorage } from "@/providers/state-provider/cookie-storage"
 
 // State that must be available during Server Component rendering
 export type ServerState = {
+  wallet: {
+    seed: `0x${string}` | undefined
+    chainId: ChainId | undefined
+    id: string | undefined
+  }
   order: {
     side: Side
     amount: string
@@ -24,18 +30,30 @@ export type ServerActions = {
   setCurrency: (currency: "base" | "quote") => void
   setBase: (base: string) => void
   setPanels: (layout: number[]) => void
+  setWallet: (seed: `0x${string}`, chainId: ChainId, id: string) => void
+  resetWallet: () => void
 }
 
 export type ServerStore = ServerState & ServerActions
 
 export const initServerStore = (): ServerState => {
   return {
+    wallet: {
+      seed: undefined,
+      chainId: undefined,
+      id: undefined,
+    },
     order: { side: Side.BUY, amount: "", currency: "base", base: "WBTC" },
     panels: { layout: [22, 78] },
   }
 }
 
 export const defaultInitState: ServerState = {
+  wallet: {
+    seed: undefined,
+    chainId: undefined,
+    id: undefined,
+  },
   order: { side: Side.BUY, amount: "", currency: "base", base: "WBTC" },
   panels: { layout: [22, 78] },
 }
@@ -57,6 +75,17 @@ export const createServerStore = (
           set((state) => ({ order: { ...state.order, base } })),
         setPanels: (layout: number[]) =>
           set((state) => ({ panels: { layout } })),
+        setWallet: (seed: `0x${string}`, chainId: ChainId, id: string) =>
+          set((state) => ({ wallet: { ...state.wallet, seed, chainId, id } })),
+        resetWallet: () =>
+          set((state) => ({
+            wallet: {
+              ...state.wallet,
+              seed: undefined,
+              chainId: undefined,
+              id: undefined,
+            },
+          })),
       }),
       {
         name: STORAGE_SERVER_STORE,

--- a/providers/wagmi-provider/config.ts
+++ b/providers/wagmi-provider/config.ts
@@ -16,7 +16,7 @@ import getDefaultConfig from "./defaultConfig"
 
 const chains: readonly [Chain, ...Chain[]] =
   env.NEXT_PUBLIC_CHAIN_ENVIRONMENT === "mainnet"
-    ? ([arbitrum, base] as const)
+    ? ([arbitrum, base, mainnet] as const)
     : ([arbitrumSepolia, baseSepolia] as const)
 
 export function getConfig() {
@@ -28,6 +28,8 @@ export function getConfig() {
         [arbitrumSepolia.id]: http(),
         [base.id]: http(),
         [baseSepolia.id]: http(),
+        // Needed to support bridge
+        [mainnet.id]: http("/api/proxy/mainnet"),
       },
       ssr: true,
       storage: createStorage({


### PR DESCRIPTION
### Purpose
This PR begins the process of lifting Renegade wallet state up from the config object to the server store that exists in the client. This is done to improve ergonomics of managing this state that is core to every part of the app; it was difficult to deal with as it existed within this `config` object. Now, we store it at the top level ServerStoreProvider (which uses the same storage as `config` does i.e. zustand with persist middleware) which allows first-class reactivity and hydration.

### Testing
- [ ] Tested locally
- [ ] Test in testnet