### PR TITLE
state: sync Wagmi state with Renegade state

### DIFF
--- a/components/dialogs/onboarding/sign-in-dialog.tsx
+++ b/components/dialogs/onboarding/sign-in-dialog.tsx
@@ -117,18 +117,12 @@ export function SignInDialog({
       config.setState((x) => ({ ...x, seed, status: "in relayer" }))
       const id = getWalletId(config)
       setWallet(seed, currentChainId as ChainId, id)
-      console.log("setWallet debug: ", {
-        seed,
-        currentChainId,
-        id,
-      })
 
       try {
         // GET wallet from relayer
         const wallet = await getWalletFromRelayer(config)
         // If success, return
         if (wallet) {
-          config.setState((x) => ({ ...x, status: "in relayer" }))
           return ConnectSuccess.ALREADY_INDEXED
         }
       } catch (error) {}

--- a/providers/wagmi-provider/theme.ts
+++ b/providers/wagmi-provider/theme.ts
@@ -1,0 +1,14 @@
+export const connectKitTheme = {
+  "--ck-body-background": "hsl(var(--background))",
+  "--ck-border-radius": "0",
+  "--ck-font-family": "var(--font-sans-extended)",
+  "--ck-primary-button-background": "hsl(var(--background))",
+  "--ck-primary-button-border-radius": "0",
+  "--ck-body-color": "hsl(var(--foreground))",
+  "--ck-body-color-muted": "hsl(var(--muted-foreground))",
+  "--ck-body-color-muted-hover": "hsl(var(--foreground))",
+  "--ck-qr-dot-color": "hsl(var(--chart-blue))",
+  "--ck-secondary-button-background": "hsl(var(--background))",
+  "--ck-qr-border-color": "hsl(var(--border))",
+  "--ck-overlay-background": "rgba(0,0,0,.8)",
+}

--- a/providers/wagmi-provider/wagmi-provider.tsx
+++ b/providers/wagmi-provider/wagmi-provider.tsx
@@ -3,11 +3,24 @@
 import React from "react"
 
 import { EVM, createConfig as createLifiConfig } from "@lifi/sdk"
-import { WagmiProvider as Provider, State } from "wagmi"
+import { ROOT_KEY_MESSAGE_PREFIX } from "@renegade-fi/react/constants"
+import { ConnectKitProvider } from "connectkit"
+import { mainnet } from "viem/chains"
+import {
+  WagmiProvider as Provider,
+  State,
+  useAccount,
+  useVerifyMessage,
+} from "wagmi"
 
+import { SignInDialog } from "@/components/dialogs/onboarding/sign-in-dialog"
+
+import { sidebarEvents } from "@/lib/events"
 import { QueryProvider } from "@/providers/query-provider"
 
+import { useServerStore } from "../state-provider/server-store-provider"
 import { getConfig } from "./config"
+import { connectKitTheme } from "./theme"
 
 createLifiConfig({
   integrator: "renegade.fi",
@@ -23,6 +36,7 @@ interface WagmiProviderProps {
 
 export function WagmiProvider({ children, initialState }: WagmiProviderProps) {
   const [config] = React.useState(() => getConfig())
+  const [open, setOpen] = React.useState(false)
 
   return (
     <Provider
@@ -30,7 +44,76 @@ export function WagmiProvider({ children, initialState }: WagmiProviderProps) {
       config={config}
       initialState={initialState}
     >
-      <QueryProvider>{children}</QueryProvider>
+      <QueryProvider>
+        <ConnectKitProvider
+          customTheme={connectKitTheme}
+          options={{
+            hideQuestionMarkCTA: true,
+            hideTooltips: true,
+            enforceSupportedChains: true,
+          }}
+          theme="midnight"
+          onConnect={() => {
+            sidebarEvents.emit("open")
+            setOpen(true)
+          }}
+        >
+          {children}
+          <SyncRenegadeWagmiState />
+          <SignInDialog
+            open={open}
+            onOpenChange={setOpen}
+          />
+        </ConnectKitProvider>
+      </QueryProvider>
     </Provider>
   )
+}
+
+/**
+ * Wagmi state is the source of truth for connected browser wallet data.
+ * We derive Renegade wallet state from Wagmi state and cache what is needed (seed, chainId, id).
+ * Cached state is used to connect to the Renegade relayer.
+ *
+ * Wagmi
+ * - on connect, ignore. sign in logic will populate the cached state
+ * - on disconnect, clear the cached state
+ * - on account switch, clear the cached state
+ * - on chain switch, clear the cached state (unless mainnet, in which case we are bridging)
+ */
+function SyncRenegadeWagmiState() {
+  const resetWallet = useServerStore((state) => state.resetWallet)
+  const signature = useServerStore((state) => state.wallet.seed)
+  const account = useAccount()
+  const isBridging = account.chainId === mainnet.id
+  const message = `${ROOT_KEY_MESSAGE_PREFIX} ${account.chainId}`
+  const address = account.address
+
+  const { data: verified } = useVerifyMessage({
+    address,
+    message,
+    signature,
+    query: {
+      // Ignore while bridging
+      enabled: !isBridging,
+    },
+  })
+
+  React.useEffect(() => {
+    if (isBridging) return
+    if (verified !== undefined && !verified) {
+      // Verification failed, clear the cached state
+      resetWallet()
+    }
+  }, [isBridging, resetWallet, verified])
+
+  React.useEffect(() => {
+    if (account.status === "disconnected") {
+      // Wagmi state may change while page is not loaded
+      // So, we check account status on mount
+      resetWallet()
+    }
+  }, [account.status, resetWallet])
+
+  return null
 }


### PR DESCRIPTION
### Purpose
This PR implements effects to keep Renegade wallet state in sync with Wagmi state. While Renegade state is derived from Wagmi state, it can be modified outside the scope of the app (in the extension, auto-lock, etc.), so we listen for these events and update Renegade wallet state accordingly.

### Testing
- [ ] Tested locally
- [ ] Test in testnet