### PR TITLE
replace renegade disconnect with resetWallet

### DIFF
--- a/app/components/wallet-sidebar/arbitrum-wallet-actions-dropdown.tsx
+++ b/app/components/wallet-sidebar/arbitrum-wallet-actions-dropdown.tsx
@@ -1,5 +1,3 @@
-import { useConfig } from "@renegade-fi/react"
-import { disconnect as disconnectRenegade } from "@renegade-fi/react/actions"
 import { Clipboard, ExternalLink, SquareX } from "lucide-react"
 import { useDisconnect } from "wagmi"
 
@@ -20,7 +18,6 @@ interface ArbitrumWalletActionsDropdownProps {
 export function ArbitrumWalletActionsDropdown({
   wallet,
 }: ArbitrumWalletActionsDropdownProps) {
-  const config = useConfig()
   const chain = useChain()
   const { disconnect } = useDisconnect()
 
@@ -38,10 +35,8 @@ export function ArbitrumWalletActionsDropdown({
   }
 
   const handleDisconnect = () => {
-    if (config) {
-      disconnectRenegade(config)
-    }
     disconnect()
+    // Allow sync to disconnect Renegade wallet
   }
 
   return (

--- a/app/components/wallet-sidebar/renegade-wallet-actions-dropdown.tsx
+++ b/app/components/wallet-sidebar/renegade-wallet-actions-dropdown.tsx
@@ -1,10 +1,6 @@
 import { useConfig } from "@renegade-fi/react"
-import {
-  disconnect as disconnectRenegade,
-  refreshWallet,
-} from "@renegade-fi/react/actions"
+import { refreshWallet } from "@renegade-fi/react/actions"
 import { Clipboard, RefreshCw, SquareX, UserCheck } from "lucide-react"
-import { useDisconnect } from "wagmi"
 
 import { Checkbox } from "@/components/ui/checkbox"
 import {
@@ -17,6 +13,7 @@ import { Label } from "@/components/ui/label"
 
 import { type Wallet } from "@/hooks/use-wallets"
 import { useClientStore } from "@/providers/state-provider/client-store-provider.tsx"
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
 
 interface RenegadeWalletActionsDropdownProps {
   wallet: Wallet
@@ -25,8 +22,8 @@ interface RenegadeWalletActionsDropdownProps {
 export function RenegadeWalletActionsDropdown({
   wallet,
 }: RenegadeWalletActionsDropdownProps) {
+  const resetWallet = useServerStore((state) => state.resetWallet)
   const config = useConfig()
-  const { disconnect } = useDisconnect()
   const { rememberMe, setRememberMe } = useClientStore((state) => state)
 
   const handleRefreshWallet = async () => {
@@ -42,10 +39,7 @@ export function RenegadeWalletActionsDropdown({
   }
 
   const handleDisconnect = () => {
-    if (config) {
-      disconnectRenegade(config)
-    }
-    disconnect()
+    resetWallet()
   }
 
   return (

--- a/components/dialogs/transfer/default-form.tsx
+++ b/components/dialogs/transfer/default-form.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden"
-import { UpdateType, getSDKConfig, useConfig } from "@renegade-fi/react"
+import { UpdateType, getSDKConfig } from "@renegade-fi/react"
 import { useQueryClient } from "@tanstack/react-query"
 import { AlertCircle, Check, Loader2 } from "lucide-react"
 import { UseFormReturn, useWatch } from "react-hook-form"
@@ -56,6 +56,7 @@ import {
 } from "@/components/ui/tooltip"
 
 import { useAllowanceRequired } from "@/hooks/use-allowance-required"
+import { useChainId } from "@/hooks/use-chain-id"
 import { useCheckChain } from "@/hooks/use-check-chain"
 import { useDeposit } from "@/hooks/use-deposit"
 import { useMediaQuery } from "@/hooks/use-media-query"
@@ -91,7 +92,7 @@ export function DefaultForm({
   form: UseFormReturn<z.infer<typeof formSchema>>
   header: React.ReactNode
 }) {
-  const chainId = useConfig()?.state.chainId
+  const chainId = useChainId()
   const { checkChain } = useCheckChain()
   const isDesktop = useMediaQuery("(min-width: 1024px)")
   const queryClient = useQueryClient()

--- a/components/dialogs/transfer/usdc-form.tsx
+++ b/components/dialogs/transfer/usdc-form.tsx
@@ -69,6 +69,7 @@ import { Separator } from "@/components/ui/separator"
 
 import { useAllowanceRequired } from "@/hooks/use-allowance-required"
 import { useChain } from "@/hooks/use-chain"
+import { useChainId } from "@/hooks/use-chain-id"
 import { useCheckChain } from "@/hooks/use-check-chain"
 import { useDeposit } from "@/hooks/use-deposit"
 import { useMediaQuery } from "@/hooks/use-media-query"
@@ -130,8 +131,8 @@ export function USDCForm({
       onError: (error) => setSwitchChainError(error),
     },
   })
-  const renegadeConfig = useConfig()
-  const chainId = useChain()?.id
+  const seed = useServerStore((state) => state.wallet.seed)
+  const chainId = useChainId()
   const publicClient = usePublicClient()
 
   const catchError = (error: Error, message: string) => {
@@ -652,7 +653,7 @@ export function USDCForm({
     if (bridgeRequired && bridgeQuote) {
       const validRecipient = await verifyRecipientAddress(
         publicClient,
-        renegadeConfig?.state.seed,
+        seed,
         bridgeQuote?.action.toAddress,
         chainId,
       )

--- a/components/dialogs/transfer/weth-form.tsx
+++ b/components/dialogs/transfer/weth-form.tsx
@@ -66,6 +66,7 @@ import {
 
 import { useAllowanceRequired } from "@/hooks/use-allowance-required"
 import { useBasePerQuotePrice } from "@/hooks/use-base-per-usd-price"
+import { useChainId } from "@/hooks/use-chain-id"
 import { useCheckChain } from "@/hooks/use-check-chain"
 import { useDeposit } from "@/hooks/use-deposit"
 import { useMediaQuery } from "@/hooks/use-media-query"
@@ -112,7 +113,7 @@ export function WETHForm({
   form: UseFormReturn<z.infer<typeof formSchema>>
   header: React.ReactNode
 }) {
-  const chainId = useConfig()?.state.chainId
+  const chainId = useChainId()
   const { address } = useAccount()
   const { checkChain } = useCheckChain()
   const isMaxBalances = useIsMaxBalances(WETH_L2_TOKEN.address)

--- a/hooks/use-chain-id.ts
+++ b/hooks/use-chain-id.ts
@@ -1,9 +1,8 @@
 "use client"
 
-import { useEffect, useState } from "react"
-
-import { Config, useConfig } from "@renegade-fi/react"
 import { ChainId } from "@renegade-fi/react/constants"
+
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
 
 /**
  * @returns The chain id of the chain the user signed in with.
@@ -12,39 +11,5 @@ import { ChainId } from "@renegade-fi/react/constants"
  * We subscribe to the state within config to ensure the value returned is reactive.
  */
 export function useChainId(): ChainId | undefined {
-  const config = useConfig()
-  const [chainId, setChainId] = useState<ChainId | undefined>(
-    config?.state.chainId as ChainId,
-  )
-
-  useEffect(() => {
-    if (!config) return
-    const unsubscribe = watchChainId(config, {
-      onChange: (chainId) => {
-        setChainId(chainId as ChainId | undefined)
-      },
-    })
-    return () => unsubscribe()
-  }, [config])
-
-  // TODO: validate at source
-  return chainId as ChainId
-}
-
-export type WatchChainIdParameters = {
-  onChange(
-    chainId: Config["state"]["chainId"],
-    prevChainId: Config["state"]["chainId"],
-  ): void
-}
-
-export type WatchChainIdReturnType = () => void
-
-export function watchChainId(
-  config: Config,
-  parameters: WatchChainIdParameters,
-): WatchChainIdReturnType {
-  const { onChange } = parameters
-
-  return config.subscribe((state) => state.chainId, onChange)
+  return useServerStore((state) => state.wallet.chainId)
 }

--- a/hooks/use-deposit.ts
+++ b/hooks/use-deposit.ts
@@ -16,11 +16,11 @@ import { FAILED_DEPOSIT_MSG } from "@/lib/constants/task"
 import { safeParseUnits } from "@/lib/format"
 import { signPermit2 } from "@/lib/permit2"
 
-import { useChain } from "./use-chain"
+import { useChainId } from "./use-chain-id"
 
 export function useDeposit() {
   const config = useConfig()
-  const chainId = useChain()?.id
+  const chainId = useChainId()
   const { data: walletClient } = useWalletClient()
   const [status, setStatus] = React.useState<MutationStatus>("idle")
   const { data: keychainNonce } = useBackOfQueueWallet({
@@ -62,8 +62,8 @@ export function useDeposit() {
     const { signature, nonce, deadline } = await signPermit2({
       amount: parsedAmount,
       chainId,
-      spender: getSDKConfig(config.state.chainId!).darkpoolAddress,
-      permit2Address: getSDKConfig(config.state.chainId!).permit2Address,
+      spender: getSDKConfig(chainId).darkpoolAddress,
+      permit2Address: getSDKConfig(chainId).permit2Address,
       token,
       walletClient,
       pkRoot,

--- a/hooks/use-sign-in-and-connect.ts
+++ b/hooks/use-sign-in-and-connect.ts
@@ -1,27 +1,23 @@
 import { useState } from "react"
 
-import { useConfig } from "@renegade-fi/react"
-import { disconnect as disconnectRenegade } from "@renegade-fi/react/actions"
 import { useModal } from "connectkit"
-import { useAccount, useDisconnect } from "wagmi"
+import { useAccount } from "wagmi"
+
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
 
 import { useRenegadeStatus } from "./use-renegade-status"
 
 export function useSignInAndConnect() {
-  const { address } = useAccount()
-  const config = useConfig()
-  const { isConnected } = useRenegadeStatus()
-  const { disconnect } = useDisconnect()
+  const { address, isConnected: isWagmiConnected } = useAccount()
+  const { isConnected: isRenegadeConnected } = useRenegadeStatus()
+  const resetWallet = useServerStore((state) => state.resetWallet)
   const { setOpen } = useModal()
   const [open, setOpenSignIn] = useState(false)
 
   const handleClick = () => {
-    if (address) {
-      if (isConnected) {
-        if (config) {
-          disconnectRenegade(config)
-        }
-        disconnect()
+    if (isWagmiConnected) {
+      if (isRenegadeConnected) {
+        resetWallet()
       } else {
         setOpenSignIn(true)
       }
@@ -32,7 +28,7 @@ export function useSignInAndConnect() {
 
   let content = ""
   if (address) {
-    if (isConnected) {
+    if (isRenegadeConnected) {
       content = `Disconnect ${address?.slice(0, 6)}`
     } else {
       content = `Sign in`

--- a/hooks/use-wallets.ts
+++ b/hooks/use-wallets.ts
@@ -44,7 +44,7 @@ export function useWallets() {
   })
 
   // Renegade
-  // Using config.state.seed && walletId because initialState loads these from cookies
+  // Using seed && wallet ID because initialState loads these from cookies
   const { seed, id } = useServerStore((state) => state.wallet)
 
   const renegadeWallet: Wallet =

--- a/providers/renegade-provider/renegade-provider.tsx
+++ b/providers/renegade-provider/renegade-provider.tsx
@@ -16,7 +16,13 @@ export function RenegadeProvider({ children }: RenegadeProviderProps) {
   const config = useMemo(() => {
     if (chainId && seed && id) {
       const config = getConfigFromChainId(chainId)
-      config.setState((x) => ({ ...x, seed, status: "in relayer", id }))
+      config.setState((x) => ({
+        ...x,
+        seed,
+        status: "in relayer",
+        id,
+        chainId,
+      }))
       return config
     }
   }, [chainId, seed, id])


### PR DESCRIPTION
### Purpose
This PR replaces invocations of the `disconnect` action with `resetWallet` which clears the server store's wallet field. We also remove unnecessary invocations of the wagmi `disconnect` action, only forcibly disconnecting the browser wallet if the user decides to.

### Testing
- [ ] Tested locally
- [ ] Test in testnet