### PR TITLE
begin migration to addres-specified base token

### DIFF
--- a/app/api/tokens/get-combined-balances/route.ts
+++ b/app/api/tokens/get-combined-balances/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 
 import { isAddress } from "viem"
+import { arbitrum } from "viem/chains"
 
 import {
   readErc20BalanceOf,
@@ -15,12 +16,11 @@ import {
   ETHEREUM_TOKENS,
   SOLANA_TOKENS,
 } from "@/lib/token"
-import { arbitrum } from "viem/chains"
 
 export const runtime = "edge"
 
 const tokens = DISPLAY_TOKENS({
-  chainId: arbitrum.id
+  chainId: arbitrum.id,
 })
 
 export async function GET(req: Request) {

--- a/app/trade/[base]/components/bbo-marquee.tsx
+++ b/app/trade/[base]/components/bbo-marquee.tsx
@@ -1,7 +1,5 @@
 import { Fragment } from "react"
 
-import { Token } from "@renegade-fi/token-nextjs"
-
 import { AnimatedPrice } from "@/components/animated-price"
 import { AnimatedPriceStatus } from "@/components/animated-price-status"
 import {
@@ -14,7 +12,7 @@ import { EXCHANGES, exchangeToName } from "@/lib/constants/protocol"
 import { BBO_TOOLTIP } from "@/lib/constants/tooltips"
 import { constructExchangeUrl } from "@/lib/utils"
 
-export function BBOMarquee({ base }: { base: string }) {
+export function BBOMarquee({ base }: { base: `0x${string}` }) {
   return (
     <div className="hidden min-h-marquee grid-cols-[0.5fr_6px_1fr_6px_1fr_6px_1fr_6px_1fr] items-center whitespace-nowrap border-b border-border font-extended text-sm lg:grid">
       <Tooltip>
@@ -36,12 +34,12 @@ export function BBOMarquee({ base }: { base: string }) {
               <AnimatedPrice
                 className="font-mono"
                 exchange={exchange}
-                mint={Token.findByTicker(base).address}
+                mint={base}
               />
               <AnimatedPriceStatus
                 className="font-extended text-green-price"
                 exchange={exchange}
-                mint={Token.findByTicker(base).address}
+                mint={base}
               />
             </div>
           </a>

--- a/app/trade/[base]/page-client.tsx
+++ b/app/trade/[base]/page-client.tsx
@@ -30,7 +30,7 @@ import { useServerStore } from "@/providers/state-provider/server-store-provider
 // Prevents re-render when side changes
 const PriceChartMemo = React.memo(PriceChart)
 
-export function PageClient({ base }: { base: string }) {
+export function PageClient({ base }: { base: `0x${string}` }) {
   const data = useOrderTableData()
   const { setBase, panels, setPanels } = useServerStore((state) => state)
   const debouncedSetPanels = useDebounceCallback(setPanels, 500)

--- a/app/trade/[base]/utils.ts
+++ b/app/trade/[base]/utils.ts
@@ -1,0 +1,151 @@
+import { cookies } from "next/headers"
+
+import type { ChainId } from "@renegade-fi/react/constants"
+import { isAddress } from "viem"
+
+import { STORAGE_SERVER_STORE } from "@/lib/constants/storage"
+import {
+  resolveAddress,
+  resolveTicker,
+  resolveTickerAndChain,
+} from "@/lib/token"
+import { cookieToInitialState } from "@/providers/state-provider/cookie-storage"
+import type { ServerState } from "@/providers/state-provider/server-store"
+import { defaultInitState } from "@/providers/state-provider/server-store"
+
+const FALLBACK_TICKER = "WETH"
+
+/**
+ * Validates that an address corresponds to a valid (non-stablecoin) token
+ */
+export function isValidTokenAddress(address: string): boolean {
+  try {
+    const token = resolveAddress(address as `0x${string}`)
+    return !token.isStablecoin()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Gets the ticker for a given token address
+ */
+export function getTickerForAddress(address: string): string {
+  try {
+    const token = resolveAddress(address as `0x${string}`)
+    return token.ticker
+  } catch {
+    return ""
+  }
+}
+
+/**
+ * Gets the base mint address from server state, with fallback to WETH
+ */
+export function getBaseMint(
+  serverState: ServerState | undefined,
+): `0x${string}` {
+  return serverState?.order.baseMint || resolveTicker(FALLBACK_TICKER).address
+}
+
+/**
+ * Hydrates server state from cookies
+ */
+export async function hydrateServerState(): Promise<ServerState> {
+  const cookieStore = await cookies()
+  const cookieVal = cookieStore.get(STORAGE_SERVER_STORE)?.value
+  const initialState =
+    cookieToInitialState(STORAGE_SERVER_STORE, cookieVal) ?? defaultInitState
+  return initialState
+}
+
+/**
+ * Resolves an address parameter to a valid token address
+ * Returns null if the input is not a valid address
+ */
+function resolveAddressParam(
+  baseParam: string,
+): { resolved: `0x${string}` } | { redirect: string } | null {
+  if (!isAddress(baseParam)) {
+    return null
+  }
+
+  const candidate = baseParam.toLowerCase()
+  if (isValidTokenAddress(candidate)) {
+    // Redirect to canonical casing if needed
+    if (candidate !== baseParam) {
+      return { redirect: `/trade/${candidate}` }
+    }
+    return { resolved: candidate }
+  }
+
+  return null
+}
+
+/**
+ * Resolves a ticker parameter to a valid token address
+ * Returns null if ticker resolution fails
+ */
+function resolveTickerParam(
+  baseParam: string,
+  chainId?: ChainId,
+): { resolved: `0x${string}` } | { redirect: string } | null {
+  try {
+    let token: any
+    let resolvedAddress: `0x${string}`
+
+    // First, try to resolve the ticker to get the canonical casing
+    if (chainId) {
+      token = resolveTickerAndChain(baseParam, chainId)
+      if (!token) throw new Error("Token not found")
+      resolvedAddress = token.address.toLowerCase() as `0x${string}`
+    } else {
+      token = resolveTicker(baseParam)
+      resolvedAddress = token.address.toLowerCase() as `0x${string}`
+    }
+
+    // Get the canonical ticker from the resolved token
+    const canonicalTicker = token.ticker
+
+    // Redirect if the input doesn't match the canonical casing
+    if (baseParam !== canonicalTicker) {
+      return { redirect: `/trade/${canonicalTicker}` }
+    }
+
+    if (isValidTokenAddress(resolvedAddress)) {
+      return { resolved: resolvedAddress }
+    }
+  } catch {
+    // Token not found
+  }
+
+  return null
+}
+
+/**
+ * Resolves a base parameter (ticker or address) to a valid token address
+ * Returns either the resolved address or a redirect instruction
+ */
+export function resolveTokenParam(
+  baseParam: string,
+  chainId?: ChainId,
+  serverState?: ServerState,
+): { resolved: `0x${string}` } | { redirect: string } {
+  // Try resolving as address first
+  const addressResult = resolveAddressParam(baseParam)
+  if (addressResult) {
+    return addressResult
+  }
+
+  // Try resolving as ticker
+  const tickerResult = resolveTickerParam(baseParam, chainId)
+  console.log("🚀 ~ tickerResult:", tickerResult)
+  if (tickerResult) {
+    return tickerResult
+  }
+
+  // Fallback to base mint ticker
+  const fallbackMint = getBaseMint(serverState)
+  const fallbackTicker = getTickerForAddress(fallbackMint).toUpperCase()
+  return { redirect: `/trade/${fallbackTicker}` }
+}

--- a/components/animated-price.tsx
+++ b/components/animated-price.tsx
@@ -9,11 +9,11 @@ import { cn } from "@/lib/utils"
 
 export function AnimatedPrice({
   className,
-  exchange = "binance",
+  exchange,
   mint,
 }: {
   className?: string
-  exchange?: Exchange
+  exchange: Exchange
   mint: `0x${string}`
 }) {
   const { data: price, isStale } = usePriceQuery(mint, exchange)

--- a/lib/price-status.ts
+++ b/lib/price-status.ts
@@ -1,5 +1,6 @@
 import { Exchange } from "@renegade-fi/react"
-import { Token } from "@renegade-fi/token-nextjs"
+
+import { resolveAddress } from "./token"
 
 /** Mapping of token price statuses with text, statusColor, and priceColor. */
 export const PRICE_STATUSES = {
@@ -37,7 +38,7 @@ export function getPriceStatus({
   mint: `0x${string}`
   exchange?: Exchange
 }) {
-  const token = Token.findByAddress(mint)
+  const token = resolveAddress(mint)
   const tokenSupported = token.supportedExchanges.has(exchange)
 
   if (!tokenSupported) {

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -1,6 +1,7 @@
 import { Exchange } from "@renegade-fi/react"
-import { getDefaultQuoteToken } from "@renegade-fi/token-nextjs"
 import { Query, QueryClient } from "@tanstack/react-query"
+
+import { getDefaultQuote } from "./token"
 
 // Helper function defining a global rule for invalidating queries
 // We invalidate queries that are:
@@ -41,7 +42,7 @@ export function createPriceTopic({
   if (!exchange || exchange === "renegade") {
     return `renegade-${base}`
   }
-  const quote = _quote ?? getDefaultQuoteToken(exchange).address
+  const quote = _quote ?? getDefaultQuote(base, exchange).address
   return `${exchange}-${base}-${quote}`
 }
 
@@ -61,7 +62,7 @@ export function createPriceQueryKey({
   if (!exchange || exchange === "renegade") {
     return ["price", "renegade", base]
   }
-  const quote = _quote ?? getDefaultQuoteToken(exchange).address
+  const quote = _quote ?? getDefaultQuote(base, exchange).address
   return ["price", exchange, base, quote]
 }
 

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -1,5 +1,6 @@
+import { Exchange } from "@renegade-fi/react"
 import { ChainId } from "@renegade-fi/react/constants"
-import { Token } from "@renegade-fi/token-nextjs"
+import { getDefaultQuoteTokenOnChain, Token } from "@renegade-fi/token-nextjs"
 import { getAddress, isAddressEqual } from "viem"
 import { mainnet } from "viem/chains"
 
@@ -34,15 +35,37 @@ export const DISPLAY_TOKENS = (
 }
 
 /**
- * Resolve the token address for a given mint across all chains
- * @param mint - The mint address
- * @returns The token address
+ * Returns the default quote token for a given mint and exchange on the chain of the mint
+ */
+export function getDefaultQuote(mint: `0x${string}`, exchange: Exchange) {
+  const chain = resolveAddress(mint).chain
+  if (!chain) {
+    return Token.create("UNKNOWN", "UNKNOWN", mint, 18, {})
+  }
+  const quote = getDefaultQuoteTokenOnChain(chain, exchange)
+  return Token.fromAddressOnChain(quote.address, chain)
+}
+
+/**
+ * Returns the first token found with the given mint address
  */
 export function resolveAddress(mint: `0x${string}`) {
   const tokens = Token.getAllTokens()
   const token = tokens.find((token) => isAddressEqual(token.address, mint))
   if (!token) {
-    throw new Error(`Token not found: ${mint}`)
+    return Token.create("UNKNOWN", "UNKNOWN", mint, 18, {})
+  }
+  return token
+}
+
+/**
+ * Returns the first token found with the given ticker
+ */
+export function resolveTicker(ticker: string) {
+  const tokens = Token.getAllTokens()
+  const token = tokens.find((token) => token.ticker === ticker)
+  if (!token) {
+    throw new Error(`Token not found: ${ticker}`)
   }
   return token
 }

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -34,13 +34,21 @@ export const DISPLAY_TOKENS = (
   return tokens
 }
 
+const DEFAULT_TOKEN = Token.create(
+  "UNKNOWN",
+  "UNKNOWN",
+  "0x0000000000000000000000000000000000000000",
+  18,
+  {},
+)
+
 /**
  * Returns the default quote token for a given mint and exchange on the chain of the mint
  */
 export function getDefaultQuote(mint: `0x${string}`, exchange: Exchange) {
   const chain = resolveAddress(mint).chain
   if (!chain) {
-    return Token.create("UNKNOWN", "UNKNOWN", mint, 18, {})
+    return DEFAULT_TOKEN
   }
   const quote = getDefaultQuoteTokenOnChain(chain, exchange)
   return Token.fromAddressOnChain(quote.address, chain)
@@ -53,7 +61,7 @@ export function resolveAddress(mint: `0x${string}`) {
   const tokens = Token.getAllTokens()
   const token = tokens.find((token) => isAddressEqual(token.address, mint))
   if (!token) {
-    return Token.create("UNKNOWN", "UNKNOWN", mint, 18, {})
+    return DEFAULT_TOKEN
   }
   return token
 }
@@ -65,7 +73,7 @@ export function resolveTicker(ticker: string) {
   const tokens = Token.getAllTokens()
   const token = tokens.find((token) => token.ticker === ticker)
   if (!token) {
-    throw new Error(`Token not found: ${ticker}`)
+    return DEFAULT_TOKEN
   }
   return token
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -8,6 +8,8 @@ import { twMerge } from "tailwind-merge"
 import { env } from "@/env/client"
 import { isTestnet } from "@/lib/viem"
 
+import { resolveAddress } from "./token"
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
@@ -210,10 +212,8 @@ export function decimalCorrectPrice(
   return correctedPrice
 }
 
-export function constructExchangeUrl(exchange: Exchange, baseTicker: string) {
-  const remappedBase = Token.findByTicker(
-    baseTicker.toUpperCase(),
-  ).getExchangeTicker(exchange)
+export function constructExchangeUrl(exchange: Exchange, mint: `0x${string}`) {
+  const remappedBase = resolveAddress(mint).getExchangeTicker(exchange)
   const remappedQuote =
     getDefaultQuoteToken(exchange).getExchangeTicker(exchange)
   if (!(remappedBase && remappedQuote)) {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@renegade-fi/internal-sdk": "0.4.12",
     "@renegade-fi/price-reporter": "0.0.0-canary-20250529193905",
     "@renegade-fi/react": "file:/Users/s/code/sdk/packages/react",
-    "@renegade-fi/token-nextjs": "^0.1.4",
+    "@renegade-fi/token-nextjs": "file:/Users/s/code/sdk/packages/token-nextjs",
     "@renegade-fi/tradingview-charts": "0.27.6",
     "@solana/wallet-adapter-base": "^0.9.23",
     "@solana/wallet-adapter-react": "^0.15.35",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: file:/Users/s/code/sdk/packages/react
         version: file:../sdk/packages/react(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@renegade-fi/token-nextjs':
-        specifier: ^0.1.4
-        version: 0.1.4(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+        specifier: file:/Users/s/code/sdk/packages/token-nextjs
+        version: file:../sdk/packages/token-nextjs(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@renegade-fi/tradingview-charts':
         specifier: 0.27.6
         version: 0.27.6
@@ -2854,15 +2854,6 @@ packages:
       '@tanstack/query-core':
         optional: true
 
-  '@renegade-fi/core@0.9.3':
-    resolution: {integrity: sha512-Hdga14rjjM3wu5QhohU+U9niqsetdff+yql20V8D6UEncOqVhb9vMFXjSDEH2Fs/EL6Fi5EaNZHp3VAHbBECdw==}
-    peerDependencies:
-      '@tanstack/query-core': '>=5.0.0'
-      viem: 2.23.11
-    peerDependenciesMeta:
-      '@tanstack/query-core':
-        optional: true
-
   '@renegade-fi/core@file:../sdk/packages/core':
     resolution: {directory: ../sdk/packages/core, type: directory}
     peerDependencies:
@@ -2887,8 +2878,8 @@ packages:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
 
-  '@renegade-fi/token-nextjs@0.1.4':
-    resolution: {integrity: sha512-YILS7rtY9ovO8B60fDweNYSA323Qlv6gx8FS9YcEJl0didmPlv5D+HHuSm4K42s86xrSksTfQHrZNtHdtcajrQ==}
+  '@renegade-fi/token-nextjs@file:../sdk/packages/token-nextjs':
+    resolution: {directory: ../sdk/packages/token-nextjs, type: directory}
 
   '@renegade-fi/token@0.0.0-canary-20250529193905':
     resolution: {integrity: sha512-dMz4YxXuvxOgI3dq/cZ3F/kIKoZNHCOyAoSjrdRRiXrYsFeQG8JXYuNl47tDxp9TUqyyyD1gU+uk/IFTuGMnMA==}
@@ -2896,8 +2887,8 @@ packages:
   '@renegade-fi/token@0.0.16':
     resolution: {integrity: sha512-eoHfIzv76wgDGL8lBgO8T8qTIabz9E/truLyWiIKRn+i3iHrn1MOEe2EnVfe6lqFElIPBq7D3Fz4BKHI3RfK+Q==}
 
-  '@renegade-fi/token@0.0.20':
-    resolution: {integrity: sha512-r0Tr3W8lHiFZiWDyQ3OlxAYCXaI3aZL3KTfOjYrHKbjxoLdsrMvVKuIvr/cGjuBf9eIc42FLccdvtIzXB6gT0A==}
+  '@renegade-fi/token@file:../sdk/packages/token':
+    resolution: {directory: ../sdk/packages/token, type: directory}
 
   '@renegade-fi/tradingview-charts@0.27.6':
     resolution: {integrity: sha512-G4hsbxxTDubarQsgp2j6oumKEi4vwk7YKf7+PulCBB2SBLMhinnbJ1OKzAlEx5BA1yc66CKtad/1kN07/8ESaQ==, tarball: https://npm.pkg.github.com/download/@renegade-fi/tradingview-charts/0.27.6/0d39f464ce268bec6cf2c0b1ff9303a51f4db26d}
@@ -11421,24 +11412,6 @@ snapshots:
       - react
       - ws
 
-  '@renegade-fi/core@0.9.3(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
-    dependencies:
-      axios: 1.7.5
-      isows: 1.0.6(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      json-bigint: 1.0.0
-      neverthrow: 8.2.0
-      tiny-invariant: 1.3.3
-      viem: 2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28)
-      zustand: 4.5.5(@types/react@19.1.4)(react@19.1.0)
-    optionalDependencies:
-      '@tanstack/query-core': 5.45.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - debug
-      - immer
-      - react
-      - ws
-
   '@renegade-fi/core@file:../sdk/packages/core(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       axios: 1.7.5
@@ -11533,10 +11506,10 @@ snapshots:
       - viem
       - ws
 
-  '@renegade-fi/token-nextjs@0.1.4(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@renegade-fi/token-nextjs@file:../sdk/packages/token-nextjs(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
-      '@renegade-fi/core': 0.9.3(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      '@renegade-fi/token': 0.0.20(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@renegade-fi/core': file:../sdk/packages/core(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@renegade-fi/token': file:../sdk/packages/token(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
     transitivePeerDependencies:
       - '@tanstack/query-core'
       - '@types/react'
@@ -11570,9 +11543,9 @@ snapshots:
       - viem
       - ws
 
-  '@renegade-fi/token@0.0.20(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@renegade-fi/token@file:../sdk/packages/token(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
-      '@renegade-fi/core': 0.9.3(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@renegade-fi/core': file:../sdk/packages/core(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
     transitivePeerDependencies:
       - '@tanstack/query-core'
       - '@types/react'

--- a/providers/state-provider/server-store.ts
+++ b/providers/state-provider/server-store.ts
@@ -4,6 +4,7 @@ import { createStore } from "zustand/vanilla"
 
 import { Side } from "@/lib/constants/protocol"
 import { STORAGE_SERVER_STORE } from "@/lib/constants/storage"
+import { resolveTicker } from "@/lib/token"
 import { createCookieStorage } from "@/providers/state-provider/cookie-storage"
 
 // State that must be available during Server Component rendering
@@ -17,7 +18,8 @@ export type ServerState = {
     side: Side
     amount: string
     currency: "base" | "quote"
-    base: string
+    baseMint: `0x${string}`
+    quoteMint: `0x${string}`
   }
   panels: {
     layout: number[]
@@ -28,7 +30,7 @@ export type ServerActions = {
   setSide: (side: Side) => void
   setAmount: (amount: string) => void
   setCurrency: (currency: "base" | "quote") => void
-  setBase: (base: string) => void
+  setBase: (baseMint: `0x${string}`) => void
   setPanels: (layout: number[]) => void
   setWallet: (seed: `0x${string}`, chainId: ChainId, id: string) => void
   resetWallet: () => void
@@ -36,6 +38,8 @@ export type ServerActions = {
 
 export type ServerStore = ServerState & ServerActions
 
+const WETH = resolveTicker("WETH")
+const USDC = resolveTicker("USDC")
 export const initServerStore = (): ServerState => {
   return {
     wallet: {
@@ -43,7 +47,13 @@ export const initServerStore = (): ServerState => {
       chainId: undefined,
       id: undefined,
     },
-    order: { side: Side.BUY, amount: "", currency: "base", base: "WBTC" },
+    order: {
+      side: Side.BUY,
+      amount: "",
+      currency: "base",
+      baseMint: WETH.address,
+      quoteMint: USDC.address,
+    },
     panels: { layout: [22, 78] },
   }
 }
@@ -54,7 +64,13 @@ export const defaultInitState: ServerState = {
     chainId: undefined,
     id: undefined,
   },
-  order: { side: Side.BUY, amount: "", currency: "base", base: "WBTC" },
+  order: {
+    side: Side.BUY,
+    amount: "",
+    currency: "base",
+    baseMint: WETH.address,
+    quoteMint: USDC.address,
+  },
   panels: { layout: [22, 78] },
 }
 
@@ -71,8 +87,13 @@ export const createServerStore = (
           set((state) => ({ order: { ...state.order, amount } })),
         setCurrency: (currency: "base" | "quote") =>
           set((state) => ({ order: { ...state.order, currency } })),
-        setBase: (base: string) =>
-          set((state) => ({ order: { ...state.order, base } })),
+        setBase: (baseMint: `0x${string}`) =>
+          set((state) => ({
+            order: {
+              ...state.order,
+              baseMint: baseMint.toLowerCase() as `0x${string}`,
+            },
+          })),
         setPanels: (layout: number[]) =>
           set((state) => ({ panels: { layout } })),
         setWallet: (seed: `0x${string}`, chainId: ChainId, id: string) =>


### PR DESCRIPTION
### Purpose
This PR beings the migration to relying on mints to uniquely identify tokens at the top level. The rationale being it's important to avoid panics and optional values where possible in the frontend, and requiring `chainID` anywhere we needed to index the token remap was too much of a footgun, especially when factoring in switching chains and other wagmi state transitions that can happen outside the purview of the interface. 

This way, the address is **always** available and correct.

The important changes are in util.ts: we add logic to parse the base mint from either a ticker or an address in the path.

### Testing
- [ ] Tested locally
- [ ] Test in testnet