### PR TITLE
fix token resolution

### DIFF
--- a/app/trade/[base]/page-client.tsx
+++ b/app/trade/[base]/page-client.tsx
@@ -31,7 +31,7 @@ import { useServerStore } from "@/providers/state-provider/server-store-provider
 // Prevents re-render when side changes
 const PriceChartMemo = React.memo(PriceChart)
 
-export function PageClient({ base }: { base: `0x${string}` }) {
+export function PageClient({ base }: { base: string }) {
   const { base: baseMint, quote: quoteMint } = useResolvePair(base)
   const data = useOrderTableData()
   const {

--- a/app/trade/[base]/page.tsx
+++ b/app/trade/[base]/page.tsx
@@ -17,7 +17,7 @@ import {
   ServerState,
 } from "@/providers/state-provider/server-store"
 
-import { resolveTokenParam } from "./utils"
+import { getResolvedTicker } from "./utils"
 
 /**
  * Hydrates server state from cookies
@@ -44,24 +44,18 @@ export default async function Page({
 }: {
   params: Promise<{ base: string }>
 }) {
-  const baseParam = (await params).base
+  const baseTicker = (await params).base
 
   // Hydrate server-side state from cookies
   const serverState = await hydrateServerState()
 
-  // Resolve ticker or address to a valid token address
-  const result = resolveTokenParam(baseParam, serverState)
+  const resolvedTicker = getResolvedTicker(baseTicker, serverState)
+  if (resolvedTicker) redirect(`/trade/${resolvedTicker}`)
 
-  // Handle redirect if needed
-  if ("redirect" in result) {
-    redirect(result.redirect)
-  }
-
-  // Render with the resolved address
   const queryClient = new QueryClient()
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <PageClient base={result.resolved} />
+      <PageClient base={baseTicker} />
     </HydrationBoundary>
   )
 }

--- a/app/trade/[base]/utils.ts
+++ b/app/trade/[base]/utils.ts
@@ -4,91 +4,34 @@ import type { ServerState } from "@/providers/state-provider/server-store"
 export const FALLBACK_TICKER = "WETH"
 
 /**
- * Validates that an address corresponds to a valid (non-stablecoin) token
+ * Resolves a ticker to the ticker to redirect to, if necessary
+ * @param ticker - The ticker to resolve
+ * @param serverState - The server state
+ * @returns The resolved ticker or undefined if no redirect is necessary
  */
-export function isValidTokenAddress(address: string): boolean {
-  try {
-    const token = resolveAddress(address as `0x${string}`)
-    return !token.isStablecoin()
-  } catch {
-    return false
-  }
-}
-
-/**
- * Gets the ticker for a given token address
- */
-export function getTickerForAddress(address: string): string {
-  try {
-    const token = resolveAddress(address as `0x${string}`)
-    return token.ticker
-  } catch {
-    return ""
-  }
-}
-
-/**
- * Gets the base mint address from server state, with fallback to WETH
- */
-export function getBaseMint(
-  serverState: ServerState | undefined,
-): `0x${string}` {
-  return serverState?.order.baseMint || resolveTicker(FALLBACK_TICKER).address
-}
-
-/**
- * Resolves a ticker parameter to a valid token address
- * Returns null if ticker resolution fails
- */
-export function resolveTickerParam(
-  baseParam: string,
-): { resolved: `0x${string}` } | { redirect: string } | null {
-  try {
-    let token: any
-    let resolvedAddress: `0x${string}`
-    token = resolveTicker(baseParam)
-    if (!token || token.address === zeroAddress)
-      throw new Error("Token not found")
-    resolvedAddress = token.address.toLowerCase() as `0x${string}`
-
-    // Get the canonical ticker from the resolved token
-    const canonicalTicker = token.ticker
-
-    // Redirect if the input doesn't match the canonical casing
-    if (baseParam !== canonicalTicker) {
-      return { redirect: `/trade/${canonicalTicker}` }
-    }
-
-    return { resolved: resolvedAddress }
-  } catch {
-    // Token not found
-  }
-
-  return null
-}
-
-/**
- * Resolves a base parameter (ticker only) to a valid token address
- * Returns either the resolved address or a redirect instruction
- */
-export function resolveTokenParam(
-  baseParam: string,
+export function getResolvedTicker(
+  ticker: string,
   serverState: ServerState,
-): { resolved: `0x${string}` } | { redirect: string } {
-  const tickerResult = resolveTickerParam(baseParam)
-  if (tickerResult && "redirect" in tickerResult) {
-    return tickerResult
-  }
-  if (
-    tickerResult &&
-    "resolved" in tickerResult &&
-    isValidTokenAddress(tickerResult.resolved)
-  ) {
-    return tickerResult
-  }
+): string | undefined {
+  const fallbackTicker = getFallbackTicker(serverState)
+  const token = resolveTicker(ticker)
 
-  // Fallback to base mint ticker
-  const fallbackMint = getBaseMint(serverState)
-  const fallbackTicker = getTickerForAddress(fallbackMint).toUpperCase()
-  return { redirect: `/trade/${fallbackTicker}` }
+  // Fallback if no token found
+  if (token.address === zeroAddress) return fallbackTicker
+  // Check if stablecoin
+  if (token.isStablecoin()) return fallbackTicker
+  // Check casing
+  if (token.ticker !== ticker) return token.ticker
+  return
+}
+
+/**
+ * Gets the cached ticker from server state, with fallback to WETH
+ */
+export function getFallbackTicker(serverState: ServerState): string {
+  if (serverState.order.baseMint) {
+    const baseToken = resolveAddress(serverState.order.baseMint)
+    return baseToken.ticker
+  }
+  return FALLBACK_TICKER
 }

--- a/hooks/use-resolve-pair.ts
+++ b/hooks/use-resolve-pair.ts
@@ -1,30 +1,77 @@
+"use client"
+
 import React from "react"
 
 import { isSupportedChainId } from "@renegade-fi/react"
 import { useAccount } from "wagmi"
 
-import { getDefaultQuote } from "@/lib/token"
+import { env } from "@/env/client"
+import {
+  getDefaultQuote,
+  resolveTicker,
+  resolveTickerAndChain,
+  zeroAddress,
+} from "@/lib/token"
+import {
+  MAINNET_CHAINS,
+  TESTNET_CHAINS,
+} from "@/providers/wagmi-provider/config"
 
-export function useResolvePair(base: `0x${string}`) {
+import { useChainId } from "./use-chain-id"
+
+export function useResolvePair(base: string) {
   const account = useAccount()
+  const renegadeChainId = useChainId()
 
   return React.useMemo(() => {
     const chainId = account.chainId
 
     // Ignore disconnected state or unsupported chains
     if (!chainId || !isSupportedChainId(chainId)) {
-      const quoteToken = getDefaultQuote(base, "renegade")
+      const baseToken = resolveTicker(base)
+      const quoteToken = getDefaultQuote(baseToken.address, "renegade")
       return {
-        base,
+        base: baseToken.address,
         quote: quoteToken.address,
       }
     }
 
-    const quoteToken = getDefaultQuote(base, "renegade")
+    // If on renegade chain and ticker exists on both chains, resolve to version on renegade chain
+    const isMultiChain = isTickerMultiChain(base)
+    if (renegadeChainId && isMultiChain) {
+      const baseToken = resolveTickerAndChain(base, renegadeChainId)
+      if (!baseToken) {
+        throw new Error(
+          `Base token ${base} not found on chain ${renegadeChainId}`,
+        )
+      }
+      const quoteToken = getDefaultQuote(baseToken.address, "renegade")
+      return {
+        base: baseToken.address,
+        quote: quoteToken.address,
+      }
+    }
+
+    // If only wagmi is connected, resolve to first match in token remaps
+    const baseToken = resolveTicker(base)
+    const quoteToken = getDefaultQuote(baseToken.address, "renegade")
 
     return {
-      base,
+      base: baseToken.address,
       quote: quoteToken.address,
     }
-  }, [account.chainId, base])
+  }, [account.chainId, base, renegadeChainId])
+}
+
+/** Returns true if the ticker exists on all chains, false otherwise */
+function isTickerMultiChain(ticker: string) {
+  const chains =
+    env.NEXT_PUBLIC_CHAIN_ENVIRONMENT === "testnet"
+      ? TESTNET_CHAINS
+      : MAINNET_CHAINS
+  for (const chain of chains) {
+    const token = resolveTickerAndChain(ticker, chain.id)
+    if (!token || token.address === zeroAddress) return false
+  }
+  return true
 }

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -65,7 +65,9 @@ export function resolveAddress(mint: `0x${string}`) {
  */
 export function resolveTicker(ticker: string) {
   const tokens = Token.getAllTokens()
-  const token = tokens.find((token) => token.ticker === ticker)
+  const token = tokens.find(
+    (token) => token.ticker.toLowerCase() === ticker.toLowerCase(),
+  )
   if (!token) {
     return DEFAULT_TOKEN
   }

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   "prettier": "./prettier.mjs",
   "pnpm": {
     "overrides": {
+      "@renegade-fi/token": "0.0.21",
       "react-is": "19.1.0",
       "viem": "$viem",
       "@types/react": "19.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@renegade-fi/token': 0.0.21
   react-is: 19.1.0
   viem: 2.23.11
   '@types/react': 19.1.4
@@ -2890,14 +2891,8 @@ packages:
   '@renegade-fi/token-nextjs@0.1.6':
     resolution: {integrity: sha512-epTa07B/CbsutBIdL4cLgw2TOuDMhFacbNsPMiJC5XJd1Ru+iMuvXhou3AWqYMr8IRjxjls79IQMHSj1jEbQfA==}
 
-  '@renegade-fi/token@0.0.0-canary-20250529193905':
-    resolution: {integrity: sha512-dMz4YxXuvxOgI3dq/cZ3F/kIKoZNHCOyAoSjrdRRiXrYsFeQG8JXYuNl47tDxp9TUqyyyD1gU+uk/IFTuGMnMA==}
-
-  '@renegade-fi/token@0.0.16':
-    resolution: {integrity: sha512-eoHfIzv76wgDGL8lBgO8T8qTIabz9E/truLyWiIKRn+i3iHrn1MOEe2EnVfe6lqFElIPBq7D3Fz4BKHI3RfK+Q==}
-
-  '@renegade-fi/token@0.0.19':
-    resolution: {integrity: sha512-EpZvmnNTRQxEHaF3w2cBYhLsREKSHIIWsMateTshNtS4apHYAtMgaAD4OwmeT6vp9/U7KbFOFYEn3ekx5lAJVg==}
+  '@renegade-fi/token@0.0.21':
+    resolution: {integrity: sha512-E3eN0gDpbfQjQSvmN+4v3XDDp8+P0w5n1PvXBIA6n2athfh3oZ9bpLoxnHZMg2ji/lp3XULEajg01LYHhAx/Rw==}
 
   '@renegade-fi/tradingview-charts@0.27.6':
     resolution: {integrity: sha512-G4hsbxxTDubarQsgp2j6oumKEi4vwk7YKf7+PulCBB2SBLMhinnbJ1OKzAlEx5BA1yc66CKtad/1kN07/8ESaQ==, tarball: https://npm.pkg.github.com/download/@renegade-fi/tradingview-charts/0.27.6/0d39f464ce268bec6cf2c0b1ff9303a51f4db26d}
@@ -11465,7 +11460,7 @@ snapshots:
       '@noble/hashes': 1.7.1
       '@renegade-fi/core': 0.9.0(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@renegade-fi/price-reporter': 0.0.16(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      '@renegade-fi/token': 0.0.16(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@renegade-fi/token': 0.0.21(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@wagmi/core': 2.16.3(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(typescript@5.4.5)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))
       axios: 1.7.5
       json-bigint: 1.0.0
@@ -11489,7 +11484,7 @@ snapshots:
   '@renegade-fi/price-reporter@0.0.0-canary-20250529193905(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       '@renegade-fi/core': 0.0.0-canary-20250529193905(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      '@renegade-fi/token': 0.0.0-canary-20250529193905(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@renegade-fi/token': 0.0.21(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       axios: 1.7.5
       neverthrow: 8.2.0
     transitivePeerDependencies:
@@ -11504,7 +11499,7 @@ snapshots:
   '@renegade-fi/price-reporter@0.0.16(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       '@renegade-fi/core': 0.9.0(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      '@renegade-fi/token': 0.0.16(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@renegade-fi/token': 0.0.21(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       axios: 1.7.5
       neverthrow: 8.2.0
     transitivePeerDependencies:
@@ -11536,7 +11531,7 @@ snapshots:
   '@renegade-fi/token-nextjs@0.1.6(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       '@renegade-fi/core': 0.9.3(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      '@renegade-fi/token': 0.0.19(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@renegade-fi/token': 0.0.21(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
     transitivePeerDependencies:
       - '@tanstack/query-core'
       - '@types/react'
@@ -11546,31 +11541,7 @@ snapshots:
       - viem
       - ws
 
-  '@renegade-fi/token@0.0.0-canary-20250529193905(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@renegade-fi/core': 0.0.0-canary-20250529193905(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-    transitivePeerDependencies:
-      - '@tanstack/query-core'
-      - '@types/react'
-      - debug
-      - immer
-      - react
-      - viem
-      - ws
-
-  '@renegade-fi/token@0.0.16(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@renegade-fi/core': 0.9.0(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-    transitivePeerDependencies:
-      - '@tanstack/query-core'
-      - '@types/react'
-      - debug
-      - immer
-      - react
-      - viem
-      - ws
-
-  '@renegade-fi/token@0.0.19(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@renegade-fi/token@0.0.21(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       '@renegade-fi/core': 0.9.3(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
     transitivePeerDependencies:
@@ -14737,8 +14708,8 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0)
       eslint-plugin-react: 7.37.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 5.0.0(eslint@8.57.0)
@@ -14760,13 +14731,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.6(supports-color@5.5.0)
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.15.1
@@ -14777,18 +14748,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -14799,7 +14770,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/providers/wagmi-provider/config.ts
+++ b/providers/wagmi-provider/config.ts
@@ -14,10 +14,13 @@ import { getURL } from "@/lib/utils"
 
 import getDefaultConfig from "./defaultConfig"
 
+export const MAINNET_CHAINS = [arbitrum, base] as const
+export const TESTNET_CHAINS = [arbitrumSepolia, baseSepolia] as const
+
 const chains: readonly [Chain, ...Chain[]] =
   env.NEXT_PUBLIC_CHAIN_ENVIRONMENT === "mainnet"
-    ? ([arbitrum, base, mainnet] as const)
-    : ([arbitrumSepolia, baseSepolia] as const)
+    ? [...MAINNET_CHAINS, mainnet]
+    : [...TESTNET_CHAINS]
 
 export function getConfig() {
   return createConfig(


### PR DESCRIPTION
### Purpose
This PR simplifies the token resolution process: we now accept only valid tickers from the URL path. These are then resolved to an address client-side using the Renegade chain ID if the ticker exists on both Arbitrum and Base. Otherwise, we pass the first matched address and rely on the switch chain button from #282 to prompt the user to switch to the correct chain to place an order.

We still store the last resolved address in cookie storage as a fallback.