### PR TITLE
server store: validate initial state using zod

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -27,7 +27,7 @@ import { useServerStore } from "@/providers/state-provider/server-store-provider
 export function Header() {
   const pathname = usePathname()
   const { walletReadyState, arbitrumWallet } = useWallets()
-  const baseMint = useServerStore((state) => state.order.baseMint)
+  const baseMint = useServerStore((state) => state.baseMint)
 
   return (
     <header className="sticky top-0 z-10 h-20 min-w-full shrink-0 border-b bg-background">

--- a/app/trade/[base]/components/new-order/amount-shortcut-button.tsx
+++ b/app/trade/[base]/components/new-order/amount-shortcut-button.tsx
@@ -37,7 +37,7 @@ export function AmountShortcutButton({
   isQuoteCurrency,
 }: AmountShortcutButtonProps) {
   const baseToken = resolveAddress(base)
-  const quoteMint = useServerStore((state) => state.order.quoteMint)
+  const quoteMint = useServerStore((state) => state.quoteMint)
   const quoteToken = resolveAddress(quoteMint)
   const { data } = useBackOfQueueWallet({
     query: {

--- a/app/trade/[base]/components/new-order/assets-section.tsx
+++ b/app/trade/[base]/components/new-order/assets-section.tsx
@@ -22,7 +22,7 @@ export function AssetsSectionWithDepositButton({
   base: `0x${string}`
 }) {
   const baseToken = resolveAddress(base)
-  const quote = useServerStore((state) => state.order.quoteMint)
+  const quote = useServerStore((state) => state.quoteMint)
   const quoteToken = resolveAddress(quote)
   const { data } = useBackOfQueueWallet({
     query: {

--- a/app/trade/[base]/components/new-order/new-order-form.tsx
+++ b/app/trade/[base]/components/new-order/new-order-form.tsx
@@ -79,7 +79,8 @@ export function NewOrderForm({
 }) {
   // Form initializaiton
   const {
-    order: { side, currency, quoteMint },
+    order: { side, currency },
+    quoteMint,
     setSide,
     setCurrency,
   } = useServerStore((state) => state)

--- a/app/trade/[base]/page-client.tsx
+++ b/app/trade/[base]/page-client.tsx
@@ -37,7 +37,7 @@ export function PageClient({ base }: { base: string }) {
   const {
     panels,
     setPanels,
-    order: { baseMint: cachedBaseMint },
+    baseMint: cachedBaseMint,
     setBase,
     setQuote,
   } = useServerStore((state) => state)

--- a/app/trade/[base]/page.tsx
+++ b/app/trade/[base]/page.tsx
@@ -12,10 +12,8 @@ import { PageClient } from "@/app/trade/[base]/page-client"
 import { STORAGE_SERVER_STORE } from "@/lib/constants/storage"
 import { DISPLAY_TOKENS } from "@/lib/token"
 import { cookieToInitialState } from "@/providers/state-provider/cookie-storage"
-import {
-  defaultInitState,
-  ServerState,
-} from "@/providers/state-provider/server-store"
+import { ServerState } from "@/providers/state-provider/schema"
+import { defaultInitState } from "@/providers/state-provider/server-store"
 
 import { getTickerRedirect } from "./utils"
 

--- a/app/trade/[base]/utils.ts
+++ b/app/trade/[base]/utils.ts
@@ -29,8 +29,8 @@ export function getTickerRedirect(
  * Gets the cached ticker from server state, with fallback to WETH
  */
 export function getFallbackTicker(serverState: ServerState): string {
-  if (serverState.order.baseMint) {
-    const baseToken = resolveAddress(serverState.order.baseMint)
+  if (serverState.baseMint) {
+    const baseToken = resolveAddress(serverState.baseMint)
     return baseToken.ticker
   }
   return FALLBACK_TICKER

--- a/app/trade/[base]/utils.ts
+++ b/app/trade/[base]/utils.ts
@@ -1,5 +1,5 @@
 import { resolveAddress, resolveTicker, zeroAddress } from "@/lib/token"
-import type { ServerState } from "@/providers/state-provider/server-store"
+import type { ServerState } from "@/providers/state-provider/schema"
 
 export const FALLBACK_TICKER = "WETH"
 

--- a/components/dialogs/order-stepper/desktop/steps/default.tsx
+++ b/components/dialogs/order-stepper/desktop/steps/default.tsx
@@ -57,7 +57,7 @@ export function DefaultStep(
   const { onNext, setTaskId } = useStepper()
 
   const baseToken = resolveAddress(props.base)
-  const quoteMint = useServerStore((state) => state.order.quoteMint)
+  const quoteMint = useServerStore((state) => state.quoteMint)
   const quoteToken = resolveAddress(quoteMint)
   const { data: price } = usePriceQuery(baseToken.address)
 
@@ -140,7 +140,7 @@ export function ConfirmOrderDisplay(
 ) {
   const isDesktop = useMediaQuery("(min-width: 1024px)")
   const token = resolveAddress(props.base)
-  const quoteMint = useServerStore((state) => state.order.quoteMint)
+  const quoteMint = useServerStore((state) => state.quoteMint)
   const parsedAmount = safeParseUnits(props.amount, token.decimals)
   const formattedAmount = formatNumber(
     parsedAmount instanceof Error ? BigInt(0) : parsedAmount,

--- a/components/dialogs/order-stepper/mobile/steps/confirm.tsx
+++ b/components/dialogs/order-stepper/mobile/steps/confirm.tsx
@@ -28,7 +28,7 @@ export function ConfirmStep(props: NewOrderConfirmationProps) {
   const { onNext, setTaskId } = useStepper()
 
   const baseToken = resolveAddress(props.base)
-  const quoteMint = useServerStore((state) => state.order.quoteMint)
+  const quoteMint = useServerStore((state) => state.quoteMint)
   const quoteToken = resolveAddress(quoteMint)
   const { data: price } = usePriceQuery(props.base)
 

--- a/components/dialogs/order-stepper/mobile/steps/default.tsx
+++ b/components/dialogs/order-stepper/mobile/steps/default.tsx
@@ -19,7 +19,7 @@ export function DefaultStep(props: {
   base: `0x${string}`
   onSubmit: (values: NewOrderConfirmationProps) => void
 }) {
-  const quoteMint = useServerStore((state) => state.order.quoteMint)
+  const quoteMint = useServerStore((state) => state.quoteMint)
   return (
     <>
       <DialogHeader className="p-0">

--- a/env/schema.ts
+++ b/env/schema.ts
@@ -1,16 +1,17 @@
-import { isSupportedChainId } from "@renegade-fi/react"
-import { ChainId } from "@renegade-fi/react/constants"
+import { CHAIN_IDS } from "@renegade-fi/react/constants"
 import z from "zod/v4"
 
 /** Zod schema for 0x-prefixed addresses */
 export const zHexString = z.templateLiteral(["0x", z.string()])
 
-/** Zod schema for accepted chain IDs */
-export const zChainId = z.coerce
-  .number()
-  .refine((val): val is ChainId => isSupportedChainId(val), {
-    message: "Invalid chain ID",
-  })
+/** Dynamically create chain ID literals from CHAIN_IDS */
+const chainIdValues = Object.values(CHAIN_IDS)
+const chainIdLiterals = chainIdValues.map((id) => z.literal(id)) as [
+  ...z.ZodLiteral<(typeof chainIdValues)[number]>[],
+]
+
+/** Zod schema for accepted chain IDs with type narrowing to number literals */
+export const zChainId = z.coerce.number().pipe(z.union(chainIdLiterals))
 
 /** Zod schema for JSON strings */
 export const zJsonString = z.string().transform((str, ctx): z.ZodJSONSchema => {

--- a/env/schema.ts
+++ b/env/schema.ts
@@ -1,19 +1,16 @@
 import { isSupportedChainId } from "@renegade-fi/react"
-import { ChainId, CHAIN_IDS } from "@renegade-fi/react/constants"
+import { ChainId } from "@renegade-fi/react/constants"
 import z from "zod/v4"
 
 /** Zod schema for 0x-prefixed addresses */
 export const zHexString = z.templateLiteral(["0x", z.string()])
 
-/** Dynamically create chain ID literals from CHAIN_IDS */
-const chainIdValues = Object.values(CHAIN_IDS)
-const chainIdLiterals = chainIdValues.map((id) => z.literal(id)) as [
-  z.ZodLiteral<(typeof chainIdValues)[0]>,
-  ...z.ZodLiteral<(typeof chainIdValues)[number]>[],
-]
-
-/** Zod schema for accepted chain IDs with type narrowing to number literals */
-export const zChainId = z.coerce.number().pipe(z.union(chainIdLiterals))
+/** Zod schema for accepted chain IDs */
+export const zChainId = z.coerce
+  .number()
+  .refine((val): val is ChainId => isSupportedChainId(val), {
+    message: "Invalid chain ID",
+  })
 
 /** Zod schema for JSON strings */
 export const zJsonString = z.string().transform((str, ctx): z.ZodJSONSchema => {

--- a/hooks/use-order-value.ts
+++ b/hooks/use-order-value.ts
@@ -26,7 +26,7 @@ export function useOrderValue({
   isQuoteCurrency,
 }: NewOrderFormProps) {
   const baseToken = resolveAddress(base)
-  const quoteMint = useServerStore((state) => state.order.quoteMint)
+  const quoteMint = useServerStore((state) => state.quoteMint)
   const quoteToken = resolveAddress(quoteMint)
   const { data: usdPerBase } = usePriceQuery(base)
 

--- a/providers/state-provider/cookie-storage.ts
+++ b/providers/state-provider/cookie-storage.ts
@@ -6,7 +6,7 @@ import {
   setCookie,
   removeCookie,
 } from "@/providers/state-provider/cookie-actions"
-import { ServerState } from "@/providers/state-provider/server-store"
+import { ServerState } from "@/providers/state-provider/schema"
 
 export const createCookieStorage = (): StateStorage => {
   return {

--- a/providers/state-provider/schema.ts
+++ b/providers/state-provider/schema.ts
@@ -18,9 +18,9 @@ export const ServerStateSchema = z.object({
     side: zSide,
     amount: z.string(),
     currency: zCurrency,
-    baseMint: zHexString,
-    quoteMint: zHexString,
   }),
+  baseMint: zHexString,
+  quoteMint: zHexString,
   panels: z.object({
     layout: z.array(z.number()),
   }),

--- a/providers/state-provider/schema.ts
+++ b/providers/state-provider/schema.ts
@@ -1,0 +1,29 @@
+import { z } from "zod/v4"
+
+import { zChainId, zHexString } from "@/env/schema"
+
+/** Zod schema for accepted sides */
+export const zSide = z.enum(["buy", "sell"])
+
+/** Zod schema for accepted currencies */
+export const zCurrency = z.enum(["base", "quote"])
+
+export const ServerStateSchema = z.object({
+  wallet: z.object({
+    seed: z.custom<`0x${string}`>().optional(),
+    chainId: zChainId.optional(),
+    id: z.string().optional(),
+  }),
+  order: z.object({
+    side: zSide,
+    amount: z.string(),
+    currency: zCurrency,
+    baseMint: zHexString,
+    quoteMint: zHexString,
+  }),
+  panels: z.object({
+    layout: z.array(z.number()),
+  }),
+})
+
+export type ServerState = z.infer<typeof ServerStateSchema>

--- a/providers/state-provider/schema.ts
+++ b/providers/state-provider/schema.ts
@@ -10,7 +10,7 @@ export const zCurrency = z.enum(["base", "quote"])
 
 export const ServerStateSchema = z.object({
   wallet: z.object({
-    seed: z.custom<`0x${string}`>().optional(),
+    seed: zHexString.optional(),
     chainId: zChainId.optional(),
     id: z.string().optional(),
   }),

--- a/providers/state-provider/server-store.ts
+++ b/providers/state-provider/server-store.ts
@@ -39,17 +39,21 @@ export const defaultInitState: ServerState = {
     side: Side.BUY,
     amount: "",
     currency: "base",
-    baseMint: WETH.address,
-    quoteMint: USDC.address,
   },
+  baseMint: WETH.address,
+  quoteMint: USDC.address,
   panels: { layout: [22, 78] },
 }
 
 export const createServerStore = (
   initState: ServerState = defaultInitState,
 ) => {
-  let validatedState = initState
-  if (!validateState(initState)) {
+  let validatedState: ServerState
+  const validationResult = validateState(initState)
+  if (validationResult) {
+    console.log("Valid state, using init state")
+    validatedState = initState
+  } else {
     console.warn("Invalid state, resetting to default state")
     validatedState = defaultInitState
   }
@@ -58,39 +62,40 @@ export const createServerStore = (
     persist(
       (set) => ({
         ...validatedState,
-        setSide: (side: Side) =>
-          set((state) => ({ order: { ...state.order, side } })),
-        setAmount: (amount: string) =>
-          set((state) => ({ order: { ...state.order, amount } })),
-        setCurrency: (currency: "base" | "quote") =>
-          set((state) => ({ order: { ...state.order, currency } })),
-        setBase: (baseMint: `0x${string}`) =>
-          set((state) => ({
-            order: {
-              ...state.order,
-              baseMint: baseMint.toLowerCase() as `0x${string}`,
-            },
-          })),
-        setQuote: (quoteMint: `0x${string}`) =>
-          set((state) => ({
-            order: {
-              ...state.order,
-              quoteMint: quoteMint.toLowerCase() as `0x${string}`,
-            },
-          })),
-        setPanels: (layout: number[]) =>
-          set((state) => ({ panels: { layout } })),
-        setWallet: (seed: `0x${string}`, chainId: ChainId, id: string) =>
-          set((state) => ({ wallet: { ...state.wallet, seed, chainId, id } })),
-        resetWallet: () =>
-          set((state) => ({
+        setSide: (side: Side) => {
+          set((state) => ({ order: { ...state.order, side } }))
+        },
+        setAmount: (amount: string) => {
+          set((state) => ({ order: { ...state.order, amount } }))
+        },
+        setCurrency: (currency: "base" | "quote") => {
+          set((state) => ({ order: { ...state.order, currency } }))
+        },
+        setBase: (baseMint: `0x${string}`) => {
+          set(() => ({
+            baseMint: baseMint.toLowerCase() as `0x${string}`,
+          }))
+        },
+        setQuote: (quoteMint: `0x${string}`) => {
+          set(() => ({
+            quoteMint: quoteMint.toLowerCase() as `0x${string}`,
+          }))
+        },
+        setPanels: (layout: number[]) => {
+          set(() => ({ panels: { layout } }))
+        },
+        setWallet: (seed: `0x${string}`, chainId: ChainId, id: string) => {
+          set((state) => ({ wallet: { ...state.wallet, seed, chainId, id } }))
+        },
+        resetWallet: () => {
+          set(() => ({
             wallet: {
-              ...state.wallet,
               seed: undefined,
               chainId: undefined,
               id: undefined,
             },
-          })),
+          }))
+        },
       }),
       {
         name: STORAGE_SERVER_STORE,

--- a/providers/wagmi-provider/wagmi-provider.tsx
+++ b/providers/wagmi-provider/wagmi-provider.tsx
@@ -102,7 +102,7 @@ function SyncRenegadeWagmiState() {
 
   const shouldClearWallet = React.useMemo(() => {
     // Clear if wagmi is disconnected
-    if (account.status === "disconnected") {
+    if (account.status === "disconnected" && signature) {
       return true
     }
 
@@ -112,7 +112,7 @@ function SyncRenegadeWagmiState() {
     }
 
     return false
-  }, [account.status, isBridging, verified])
+  }, [account.status, isBridging, signature, verified])
 
   React.useEffect(() => {
     if (shouldClearWallet) {


### PR DESCRIPTION
### Purpose
This PR ensures the state read from cookies to initialize the server store is validated to prevent panics due to corrupted state.

We also move `baseMint` and `quoteMint` to the top level of the state object to obviate potential issues due to overwriting slices of state.

### Testing
- [x] Tested locally
- [x] Test in testnet
- [x] Andrew test using his corrupted browser state