### PR TITLE
stats: transfers: chain-specific erc20 transfer fetching

### DIFF
--- a/app/api/alchemy-transfers.ts
+++ b/app/api/alchemy-transfers.ts
@@ -1,0 +1,84 @@
+import { getSDKConfig } from "@renegade-fi/react"
+
+import { getAlchemyRpcUrl } from "@/app/api/utils"
+
+import { DISPLAY_TOKENS } from "@/lib/token"
+
+export interface AlchemyTransfer {
+  blockNum: string
+  hash: string
+  from: string
+  to: string
+  rawContract: {
+    value: string
+    address: string
+    decimal: string
+  }
+  metadata: {
+    blockTimestamp: string
+  }
+}
+
+/**
+ * Fetches all ERC-20 asset transfers from Alchemy, paginated, filtered by darkpool address.
+ * @param fromBlock - Hex string (e.g., "0x1234") to start from
+ * @param isWithdrawal - If true, filter by fromAddress (withdrawals), else toAddress (deposits)
+ * @param chainId - Chain ID for Alchemy RPC and darkpool address
+ */
+export async function getAssetTransfers({
+  fromBlock,
+  isWithdrawal,
+  chainId,
+}: {
+  fromBlock: bigint
+  isWithdrawal: boolean
+  chainId: number
+}): Promise<AlchemyTransfer[]> {
+  const darkpool = getSDKConfig(chainId).darkpoolAddress.toLowerCase()
+  const tokenAddresses = DISPLAY_TOKENS({ chainId }).map((t) => t.address)
+  const baseParams: Record<string, any> = {
+    fromBlock: `0x${fromBlock.toString(16)}`,
+    toBlock: "latest",
+    contractAddresses: tokenAddresses,
+    category: ["erc20"],
+    withMetadata: true,
+    excludeZeroValue: false,
+    maxCount: "0xa",
+    order: "desc",
+  }
+  // set direction
+  if (isWithdrawal) baseParams.fromAddress = darkpool
+  else baseParams.toAddress = darkpool
+
+  const result: AlchemyTransfer[] = []
+  let pageKey: string | undefined = undefined
+
+  do {
+    const params: Record<string, any> = {
+      ...baseParams,
+      ...(pageKey ? { pageKey } : {}),
+    }
+    const body: string = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "alchemy_getAssetTransfers",
+      params: [params],
+    })
+    const response: Response = await fetch(getAlchemyRpcUrl(chainId), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    })
+    if (!response.ok) {
+      throw new Error(
+        `Alchemy getAssetTransfers HTTP error: ${response.status}`,
+      )
+    }
+    const json: any = await response.json()
+    const transfers = json.result.transfers as AlchemyTransfer[]
+    result.push(...transfers)
+    pageKey = json.result.pageKey
+  } while (pageKey)
+
+  return result
+}

--- a/app/api/get-logs/route.ts
+++ b/app/api/get-logs/route.ts
@@ -6,7 +6,7 @@ import { arbitrum } from "viem/chains"
 
 import { getAlchemyRpcUrl } from "@/app/api/utils"
 
-import { env } from "@/env/server"
+import { getDeployBlock } from "@/lib/viem"
 
 export const runtime = "edge"
 
@@ -33,6 +33,7 @@ export async function GET(req: NextRequest) {
         wallet_blinder_share: blinderShare,
       },
     })
+    const deployBlock = getDeployBlock(chainId) ?? BigInt(0)
 
     // Make raw JSON-RPC call
     const response = await fetch(getAlchemyRpcUrl(arbitrum.id), {
@@ -46,7 +47,7 @@ export async function GET(req: NextRequest) {
           {
             address: getSDKConfig(chainId).darkpoolAddress,
             topics,
-            fromBlock: toHex(env.ARBITRUM_DEPLOY_BLOCK),
+            fromBlock: toHex(deployBlock),
           },
         ],
       }),

--- a/app/api/stats/constants.ts
+++ b/app/api/stats/constants.ts
@@ -1,6 +1,15 @@
-export const INFLOWS_SET_KEY = "stats:inflows:set"
-export const INFLOWS_KEY = "stats:inflows"
-export const LAST_PROCESSED_BLOCK_KEY = "stats:inflows:last_processed_block"
+export function getInflowsSetKey(chainId: number): string {
+  return `stats:inflows:${chainId}:set`
+}
+
+export function getInflowsKey(chainId: number): string {
+  return `stats:inflows:${chainId}`
+}
+
+export function getLastProcessedBlockKey(chainId: number): string {
+  return `stats:inflows:${chainId}:last_processed_block`
+}
+
 export const BLOCK_CHUNK_SIZE = 10 // Adjust this value based on rate limit constraints
 
 export type ExternalTransferData = {
@@ -25,3 +34,7 @@ export const HISTORICAL_VOLUME_SET_KEY = "stats:historical-volume:set"
 // Flows
 
 export const NET_FLOW_KEY = "net_flow_24h"
+
+export function getNetFlowKey(chainId: number): string {
+  return `${NET_FLOW_KEY}:${chainId}`
+}

--- a/app/api/stats/set-inflow-kv/route.ts
+++ b/app/api/stats/set-inflow-kv/route.ts
@@ -1,60 +1,45 @@
 import { NextRequest } from "next/server"
 
+import { getSDKConfig } from "@renegade-fi/react"
 import { kv } from "@vercel/kv"
-import {
-  createPublicClient,
-  formatUnits,
-  http,
-  isAddress,
-  parseAbiItem,
-} from "viem"
-import { arbitrum } from "viem/chains"
+import { formatUnits } from "viem"
 
+import { AlchemyTransfer, getAssetTransfers } from "@/app/api/alchemy-transfers"
 import { fetchAssetPrice } from "@/app/api/amberdata/helpers"
 import {
-  BLOCK_CHUNK_SIZE,
   ExternalTransferData,
-  INFLOWS_KEY,
-  INFLOWS_SET_KEY,
-  LAST_PROCESSED_BLOCK_KEY,
+  getInflowsKey,
+  getInflowsSetKey,
+  getLastProcessedBlockKey,
 } from "@/app/api/stats/constants"
-import { getAlchemyRpcUrl } from "@/app/api/utils"
 
 import { env } from "@/env/server"
 import { amountTimesPrice } from "@/hooks/use-usd-price"
 import { DISPLAY_TOKENS, remapToken, resolveAddress } from "@/lib/token"
-import { arbitrumSDKConfig } from "@/lib/viem"
-
-const viemClient = createPublicClient({
-  chain: arbitrum,
-  transport: http(getAlchemyRpcUrl(arbitrum.id)),
-})
+import { getDeployBlock } from "@/lib/viem"
 
 export const maxDuration = 300
 
-async function getBlockTimestamps(
-  blockNumbers: bigint[],
-): Promise<Map<bigint, bigint>> {
-  const blockNumberToTimestamp = new Map<bigint, bigint>()
-  for (let i = 0; i < blockNumbers.length; i += BLOCK_CHUNK_SIZE) {
-    const chunk = blockNumbers.slice(i, i + BLOCK_CHUNK_SIZE)
-    const blockPromises = chunk.map((blockNumber) =>
-      viemClient.getBlock({ blockNumber }),
-    )
-    const blocks = await Promise.all(blockPromises)
-    blocks.forEach((block) =>
-      blockNumberToTimestamp.set(block.number, block.timestamp),
-    )
-  }
-  return blockNumberToTimestamp
-}
-
 export async function GET(req: NextRequest) {
   console.log("Starting POST request: set-inflow-kv")
+  // Parse and validate chainId
+  const chainIdParam = req.nextUrl.searchParams.get("chainId")
+  const chainId = Number(chainIdParam)
+  if (isNaN(chainId)) {
+    return new Response(
+      JSON.stringify({ error: `Invalid chainId: ${chainIdParam}` }),
+      { status: 400 },
+    )
+  }
+  // Build dynamic clients and keys
+  const sdkConfig = getSDKConfig(chainId)
+  const inflowsKey = getInflowsKey(chainId)
+  const inflowsSetKey = getInflowsSetKey(chainId)
+  const lastProcessedBlockKey = getLastProcessedBlockKey(chainId)
   try {
     // Get all token prices
     console.log("Fetching token prices")
-    const tokens = DISPLAY_TOKENS()
+    const tokens = DISPLAY_TOKENS({ chainId })
 
     const pricePromises = tokens.map((token) =>
       fetchAssetPrice(remapToken(token.address), env.AMBERDATA_API_KEY),
@@ -68,70 +53,68 @@ export async function GET(req: NextRequest) {
     console.log(`Fetched prices for ${priceData.length} tokens`)
 
     // Get the last processed block number
-    let fromBlock = BigInt(
-      (await kv.get(LAST_PROCESSED_BLOCK_KEY)) || env.ARBITRUM_DEPLOY_BLOCK,
-    )
+    const deployBlock = getDeployBlock(chainId) ?? BigInt(0)
+    const lastProcessedFromKV = await kv.get(lastProcessedBlockKey)
+    const fromBlock = lastProcessedFromKV
+      ? BigInt(Number(lastProcessedFromKV))
+      : deployBlock
     console.log(`Starting from block: ${fromBlock}`)
 
-    // Get all external transfer logs
-    console.log("Fetching external transfer logs")
-    const logs = await viemClient.getLogs({
-      // @sehyunc TODO: remove hardcoded chain id
-      address: arbitrumSDKConfig.darkpoolAddress,
-      event: parseAbiItem(
-        "event ExternalTransfer(address indexed account, address indexed mint, bool indexed is_withdrawal, uint256 amount)",
-      ),
-      fromBlock: fromBlock,
-    })
-    console.log(`Fetched ${logs.length} logs`)
-
-    if (logs.length === 0) {
-      console.log("No new logs to process")
-      return new Response(JSON.stringify({ message: "No new logs to process" }))
+    // Get external transfer logs
+    console.log("Fetching external transfer logs", sdkConfig.darkpoolAddress)
+    const [depositTransfers, withdrawTransfers] = await Promise.all([
+      getAssetTransfers({
+        fromBlock,
+        isWithdrawal: false,
+        chainId,
+      }),
+      getAssetTransfers({
+        fromBlock,
+        isWithdrawal: true,
+        chainId,
+      }),
+    ])
+    const rawTransfers: AlchemyTransfer[] = [
+      ...depositTransfers,
+      ...withdrawTransfers,
+    ]
+    if (rawTransfers.length === 0) {
+      console.log("No new transfers to process")
+      return new Response(
+        JSON.stringify({ message: "No new transfers to process" }),
+      )
     }
+    console.log(`Fetched ${rawTransfers.length} transfers from Alchemy`)
+    // Process all raw transfers
+    console.log("Processing transfers")
+    const processPromises = rawTransfers.map(async (raw) => {
+      const mint = raw.rawContract.address as `0x${string}`
+      const token = resolveAddress(mint)
+      const price = priceData.find((tp) => tp.ticker === token.ticker)?.price
+      if (!price) return null
 
-    // Get timestamps for all blocks (chunked)
-    console.log("Fetching block timestamps")
-    const uniqueBlockNumbers = Array.from(
-      new Set(logs.map((log) => log.blockNumber)),
-    )
-    const blockNumberToTimestamp = await getBlockTimestamps(uniqueBlockNumbers)
-    console.log(`Fetched timestamps for ${uniqueBlockNumbers.length} blocks`)
+      const rawAmount = BigInt(raw.rawContract.value)
+      const usdVolumeBigInt = amountTimesPrice(rawAmount, price)
+      const amount = parseFloat(formatUnits(usdVolumeBigInt, token.decimals))
 
-    // Process all logs
-    console.log("Processing logs")
-    const processPromises = logs.map(async (log) => {
-      const mint = log.args.mint?.toString().toLowerCase()
-      if (mint && isAddress(mint)) {
-        const token = resolveAddress(mint)
-        const price = priceData.find((tp) => tp.ticker === token?.ticker)?.price
-        if (price && token && log.args.amount) {
-          const usdVolume = amountTimesPrice(log.args.amount, price)
-          const formatted = parseFloat(formatUnits(usdVolume, token.decimals))
-          const timestamp = blockNumberToTimestamp.get(log.blockNumber)
+      const timestamp = new Date(raw.metadata.blockTimestamp).getTime()
 
-          if (timestamp) {
-            const data: ExternalTransferData = {
-              timestamp: Number(timestamp) * 1000,
-              amount: formatted,
-              isWithdrawal: Boolean(log.args.is_withdrawal),
-              mint,
-              transactionHash: log.transactionHash,
-            }
+      const isWithdrawal =
+        raw.from.toLowerCase() === sdkConfig.darkpoolAddress.toLowerCase()
 
-            // Write to KV store and add to Set
-            await Promise.all([
-              kv.set(
-                `${INFLOWS_KEY}:${log.transactionHash}`,
-                JSON.stringify(data),
-              ),
-              kv.sadd(INFLOWS_SET_KEY, log.transactionHash),
-            ])
-            return data
-          }
-        }
+      const data: ExternalTransferData = {
+        timestamp,
+        amount,
+        isWithdrawal,
+        mint,
+        transactionHash: raw.hash,
       }
-      return null
+
+      await Promise.all([
+        kv.set(`${inflowsKey}:${raw.hash}`, JSON.stringify(data)),
+        kv.sadd(inflowsSetKey, raw.hash),
+      ])
+      return data
     })
 
     const results = await Promise.all(processPromises)
@@ -141,8 +124,10 @@ export async function GET(req: NextRequest) {
     console.log(`Successfully processed ${processedResults.length} logs`)
 
     // Store the last processed block number
-    const lastProcessedBlock = logs[logs.length - 1].blockNumber
-    await kv.set(LAST_PROCESSED_BLOCK_KEY, lastProcessedBlock.toString())
+    const lastProcessedBlock = rawTransfers
+      .map((r) => BigInt(r.blockNum))
+      .reduce((max, b) => (b > max ? b : max), BigInt(0))
+    await kv.set(lastProcessedBlockKey, lastProcessedBlock.toString())
     console.log(`Updated last processed block to ${lastProcessedBlock}`)
 
     console.log("POST request completed successfully")

--- a/app/api/utils.ts
+++ b/app/api/utils.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionData, hexToBigInt, parseAbi } from "viem"
+import { encodeFunctionData, parseAbi } from "viem"
 import {
   arbitrum,
   arbitrumSepolia,
@@ -69,7 +69,7 @@ export async function readErc20BalanceOf(
     })
 
     const result = await response.json()
-    return hexToBigInt(result.result)
+    return BigInt(result.result)
   } catch (error) {
     console.error("Error fetching balance", {
       rpcUrl,
@@ -98,7 +98,7 @@ export async function readEthBalance(
     })
 
     const result = await response.json()
-    return hexToBigInt(result.result)
+    return BigInt(result.result)
   } catch (error) {
     console.error("Error reading ETH balance", {
       rpcUrl,
@@ -186,5 +186,5 @@ export async function fetchTvl(
     throw new Error(`RPC error: ${result.error.message}`)
   }
 
-  return hexToBigInt(result.result)
+  return BigInt(result.result)
 }

--- a/app/stats/charts/inflows-chart.tsx
+++ b/app/stats/charts/inflows-chart.tsx
@@ -33,8 +33,8 @@ const chartConfig = {
   },
 } satisfies ChartConfig
 
-export function InflowsChart() {
-  const { data } = useExternalTransferLogs()
+export function InflowsChart({ chainId }: { chainId: number }) {
+  const { data } = useExternalTransferLogs({ chainId })
 
   const chartData = React.useMemo(() => {
     if (!data || !data.length) return []

--- a/app/stats/hooks/use-external-transfer-data.ts
+++ b/app/stats/hooks/use-external-transfer-data.ts
@@ -5,15 +5,21 @@ import { ExternalTransferLogsResponse } from "@/app/api/stats/external-transfer-
 
 import { env } from "@/env/client"
 
-export function useExternalTransferLogs(intervalMs: number = 86400000) {
-  const queryKey = ["stats", "externalTransferLogs", intervalMs]
+export function useExternalTransferLogs({
+  intervalMs = 86400000,
+  chainId,
+}: {
+  intervalMs?: number
+  chainId: number
+}) {
+  const queryKey = ["stats", "externalTransferLogs", intervalMs, chainId]
 
   return {
     ...useQuery<BucketData[], Error>({
       queryKey,
-      queryFn: () => fetchExternalTransferLogs(intervalMs),
+      queryFn: () => fetchExternalTransferLogs(intervalMs, chainId),
       staleTime: Infinity,
-      enabled: env.NEXT_PUBLIC_VERCEL_ENV === "production",
+      enabled: env.NEXT_PUBLIC_CHAIN_ENVIRONMENT === "mainnet",
     }),
     queryKey,
   }
@@ -21,9 +27,10 @@ export function useExternalTransferLogs(intervalMs: number = 86400000) {
 
 const fetchExternalTransferLogs = async (
   intervalMs: number,
+  chainId: number,
 ): Promise<BucketData[]> => {
   const response = await fetch(
-    `/api/stats/external-transfer-logs?interval=${intervalMs}`,
+    `/api/stats/external-transfer-logs?interval=${intervalMs}&chainId=${chainId}`,
   )
   if (!response.ok) {
     throw new Error("Failed to fetch external transfer logs")

--- a/app/stats/page-client.tsx
+++ b/app/stats/page-client.tsx
@@ -80,7 +80,7 @@ export function PageClient() {
           <h1 className="mb-4 mt-6 font-serif text-3xl font-bold tracking-tighter lg:tracking-normal">
             Inflows
           </h1>
-          <InflowsChart />
+          <InflowsChart chainId={selectedChainId} />
         </div>
       </div>
     </main>

--- a/env/client.ts
+++ b/env/client.ts
@@ -23,6 +23,12 @@ export const env = createEnv({
     /** Vercel-generated URL for preview deployments */
     NEXT_PUBLIC_VERCEL_URL: z.string().optional(),
 
+    /** Darkpool contract deployment block number on Arbitrum */
+    NEXT_PUBLIC_ARBITRUM_DEPLOY_BLOCK: z.coerce.bigint().optional(),
+
+    /** Darkpool contract deployment block number on Base */
+    NEXT_PUBLIC_BASE_DEPLOY_BLOCK: z.coerce.bigint().optional(),
+
     // ================================
     // Token Mapping
     // ================================
@@ -50,6 +56,9 @@ export const env = createEnv({
     NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: z.string().min(1),
   },
   runtimeEnv: {
+    NEXT_PUBLIC_ARBITRUM_DEPLOY_BLOCK:
+      process.env.NEXT_PUBLIC_ARBITRUM_DEPLOY_BLOCK,
+    NEXT_PUBLIC_BASE_DEPLOY_BLOCK: process.env.NEXT_PUBLIC_BASE_DEPLOY_BLOCK,
     NEXT_PUBLIC_ARBITRUM_TOKEN_MAPPING:
       process.env.NEXT_PUBLIC_ARBITRUM_TOKEN_MAPPING,
     NEXT_PUBLIC_BASE_TOKEN_MAPPING: process.env.NEXT_PUBLIC_BASE_TOKEN_MAPPING,

--- a/env/server.ts
+++ b/env/server.ts
@@ -12,9 +12,6 @@ export const env = createEnv({
     /** Alchemy API key for multi-chain RPC access */
     ALCHEMY_API_KEY: z.string().min(1),
 
-    /** Darkpool contract deployment block number on Arbitrum */
-    ARBITRUM_DEPLOY_BLOCK: z.number().default(0),
-
     // ================================
     // External Services
     // ================================

--- a/lib/viem.ts
+++ b/lib/viem.ts
@@ -88,5 +88,19 @@ export function getChainLogoTicker(chainId: number): string {
   }
 }
 
+/** Get the deploy block for a given chain */
+export function getDeployBlock(chainId: number) {
+  switch (chainId) {
+    case arbitrum.id:
+    case arbitrumSepolia.id:
+      return env.NEXT_PUBLIC_ARBITRUM_DEPLOY_BLOCK
+    case base.id:
+    case baseSepolia.id:
+      return env.NEXT_PUBLIC_BASE_DEPLOY_BLOCK
+    default:
+      return BigInt(0)
+  }
+}
+
 // TODO: Remove this once stats are recorded for all chains
 export const arbitrumSDKConfig = getSDKConfig(arbitrum.id)

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,11 @@
 {
   "crons": [
     {
-      "path": "/api/stats/set-inflow-kv",
+      "path": "/api/stats/set-inflow-kv?chainId=42161",
+      "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/stats/set-inflow-kv?chainId=8453",
       "schedule": "* * * * *"
     },
     {


### PR DESCRIPTION
### Purpose
This PR modifies the route handlers responsible for transfer stats to be chain-aware. We switched to using Alchemy's getAssetTransfer RPC instead of fetching ExternalTransfer logs because the Base contract does not emit them.

I also backfilled the KV store with Arbitrum + Base transfer data to test + migrate.

### Testing
- [x] Tested locally
- [ ] Test in testnet