### PR TITLE
price display: dynamic formatting based on value

### DIFF
--- a/app/trade/[base]/components/mobile-asset-price-accordion.tsx
+++ b/app/trade/[base]/components/mobile-asset-price-accordion.tsx
@@ -48,7 +48,6 @@ export function MobileAssetPriceAccordion({ base }: { base: `0x${string}` }) {
               </div>
               <AnimatedPrice
                 className="font-mono text-xl"
-                exchange="binance"
                 mint={base}
               />
               <ChevronDown className="ml-2 h-4 w-4 transition-transform duration-200" />

--- a/components/animated-price.tsx
+++ b/components/animated-price.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { Exchange } from "@renegade-fi/react"
 
 import { usePriceQuery } from "@/hooks/use-price-query"
-import { formatCurrency } from "@/lib/format"
+import { formatDynamicCurrency } from "@/lib/format"
 import { getPriceStatus } from "@/lib/price-status"
 import { cn } from "@/lib/utils"
 
@@ -42,7 +42,7 @@ export function AnimatedPrice({
         "animate-price-red": price < prev.current,
       })}
     >
-      {formatCurrency(price)}
+      {formatDynamicCurrency(price)}
     </span>
   )
 }

--- a/hooks/use-price-query.ts
+++ b/hooks/use-price-query.ts
@@ -9,7 +9,7 @@ import { isSupportedExchange } from "@/lib/token"
 
 import { usePriceWebSocket } from "./use-price-websocket"
 
-const STALE_TIME_MS = 60_000
+export const STALE_TIME_MS = 60_000
 
 export function usePriceQuery(
   baseMint: `0x${string}`,

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -169,3 +169,26 @@ export function formatDuration(ms: number | undefined): string | undefined {
   if (!ms) return undefined
   return dayjs.duration(ms, "milliseconds").humanize()
 }
+
+// Format currency with dynamic precision based on magnitude
+export function formatDynamicCurrency(value: number): string {
+  if (value <= 0) {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(0)
+  }
+  const exponent = Math.floor(Math.log10(value))
+  let decimals = Math.max(2, -exponent)
+  if (value < 1) {
+    decimals += 1
+  }
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  }).format(value)
+}


### PR DESCRIPTION
### Purpose
This PR introduces a custom formatter for currencies that takes into account the value being formatted to choose decimal counts that are not too reductive. Fixes an issue where sub-cent token prices were being rounded to '<$0.01'.

### Testing
- [ ] Tested locally