### PR TITLE
fix reactive websocket connection

### DIFF
--- a/app/assets/page-client.tsx
+++ b/app/assets/page-client.tsx
@@ -19,6 +19,7 @@ import { useAssetsTableData } from "@/hooks/use-assets-table-data"
 import { useChainId } from "@/hooks/use-chain-id"
 import { ASSETS_TOOLTIP } from "@/lib/constants/tooltips"
 import { DISPLAY_TOKENS, resolveAddress } from "@/lib/token"
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
 
 import { columns as assetColumns } from "./assets-table/columns"
 import { columns as historyColumns } from "./history-table/columns"
@@ -53,8 +54,12 @@ export function PageClient() {
   }, [rawTableData, showZeroOnChainBalance, showZeroRenegadeBalance])
 
   // Transfer History Table Data
+  const wallet = useServerStore((state) => state.wallet)
   const { data: transferHistory } = useTaskHistory({
     limit: 1000,
+    seed: wallet.seed,
+    walletId: wallet.id,
+    chainId: wallet.chainId,
     query: {
       select: (data) => Array.from(data.values()),
     },

--- a/app/components/deposit-banner.tsx
+++ b/app/components/deposit-banner.tsx
@@ -1,11 +1,11 @@
 import React from "react"
 
-import { useBackOfQueueWallet } from "@renegade-fi/react"
 import { ArrowRight } from "lucide-react"
 
 import { TransferDialog } from "@/components/dialogs/transfer/transfer-dialog"
 import { Button } from "@/components/ui/button"
 
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 import { useChainName } from "@/hooks/use-chain-name"
 import { useMediaQuery } from "@/hooks/use-media-query"
 

--- a/app/components/invalidate-queries.tsx
+++ b/app/components/invalidate-queries.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { useTaskHistoryWebSocket } from "@renegade-fi/react"
 import { useQueryClient } from "@tanstack/react-query"
 
+import { useTaskHistoryWebSocket } from "@/hooks/use-task-history-websocket"
 import { shouldInvalidate } from "@/lib/query"
 
 export function InvalidateQueries() {

--- a/app/components/order-toaster.tsx
+++ b/app/components/order-toaster.tsx
@@ -2,18 +2,15 @@
 
 import React from "react"
 
-import {
-  OrderMetadata,
-  OrderState,
-  useBackOfQueueWallet,
-  useOrderHistory,
-  useOrderHistoryWebSocket,
-} from "@renegade-fi/react"
+import { OrderMetadata, OrderState, useOrderHistory } from "@renegade-fi/react"
 import { toast } from "sonner"
 
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
+import { useOrderHistoryWebSocket } from "@/hooks/use-order-history-websocket"
 import { formatNumber } from "@/lib/format"
 import { syncOrdersWithWalletState } from "@/lib/order"
 import { resolveAddress } from "@/lib/token"
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
 
 export function OrderToaster() {
   const [incomingOrder, setIncomingOrder] = React.useState<OrderMetadata>()
@@ -29,7 +26,11 @@ export function OrderToaster() {
       select: (data) => data.orders.map((order) => order.id),
     },
   })
+  const wallet = useServerStore((state) => state.wallet)
   const { data } = useOrderHistory({
+    seed: wallet.seed,
+    walletId: wallet.id,
+    chainId: wallet.chainId,
     query: {
       enabled: orderMetadataRef.current.size === 0,
       select: (data) =>

--- a/app/components/task-toaster.tsx
+++ b/app/components/task-toaster.tsx
@@ -2,10 +2,11 @@
 
 import React from "react"
 
-import { Task, useTaskHistoryWebSocket } from "@renegade-fi/react"
+import { Task } from "@renegade-fi/react"
 import { Loader2 } from "lucide-react"
 import { toast } from "sonner"
 
+import { useTaskHistoryWebSocket } from "@/hooks/use-task-history-websocket"
 import {
   formatTaskState,
   generateCompletionToastMessage,

--- a/app/components/wallet-sidebar/hooks/use-unviewed-fills.ts
+++ b/app/components/wallet-sidebar/hooks/use-unviewed-fills.ts
@@ -1,18 +1,16 @@
 import React from "react"
 
-import {
-  OrderMetadata,
-  useBackOfQueueWallet,
-  useOrderHistory,
-} from "@renegade-fi/react"
+import { OrderMetadata, useOrderHistory } from "@renegade-fi/react"
 
 import {
   generateFillIdentifier,
   useViewedFills,
 } from "@/app/components/wallet-sidebar/hooks/use-viewed-fills"
 
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 import { syncOrdersWithWalletState } from "@/lib/order"
 import { useClientStore } from "@/providers/state-provider/client-store-provider.tsx"
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
 
 export function useRecentUnviewedFills() {
   const { lastVisitTs } = useClientStore((state) => state)
@@ -26,7 +24,11 @@ export function useRecentUnviewedFills() {
       select: (data) => data.orders.map((order) => order.id),
     },
   })
+  const wallet = useServerStore((state) => state.wallet)
   const { data: orders } = useOrderHistory({
+    seed: wallet.seed,
+    walletId: wallet.id,
+    chainId: wallet.chainId,
     query: {
       select: (data) => {
         if (!lastVisitBigInt) return []

--- a/app/orders/columns.tsx
+++ b/app/orders/columns.tsx
@@ -1,4 +1,4 @@
-import { OrderState, useBackOfQueueWallet } from "@renegade-fi/react"
+import { OrderState } from "@renegade-fi/react"
 import { ColumnDef, RowData } from "@tanstack/react-table"
 import { ChevronDown, ChevronUp, ChevronsUpDown } from "lucide-react"
 import { formatUnits } from "viem/utils"
@@ -14,6 +14,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 import { useIsOrderUndercapitalized } from "@/hooks/use-is-order-undercapitalized"
 import { ExtendedOrderMetadata } from "@/hooks/use-order-table-data"
 import { useSavingsAcrossFillsQuery } from "@/hooks/use-savings-across-fills-query"

--- a/app/trade/[base]/components/new-order/amount-shortcut-button.tsx
+++ b/app/trade/[base]/components/new-order/amount-shortcut-button.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 
-import { useBackOfQueueWallet } from "@renegade-fi/react"
 import { formatUnits } from "viem"
 
 import { NewOrderFormProps } from "@/app/trade/[base]/components/new-order/new-order-form"
@@ -12,6 +11,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 import { usePriceQuery } from "@/hooks/use-price-query"
 import { useUSDPrice } from "@/hooks/use-usd-price"
 import { PRICE_DECIMALS } from "@/lib/constants/precision"

--- a/app/trade/[base]/components/new-order/assets-section.tsx
+++ b/app/trade/[base]/components/new-order/assets-section.tsx
@@ -1,4 +1,3 @@
-import { useBackOfQueueWallet } from "@renegade-fi/react"
 import { formatUnits } from "viem/utils"
 
 import { TransferDialog } from "@/components/dialogs/transfer/transfer-dialog"
@@ -10,6 +9,7 @@ import {
   ResponsiveTooltipTrigger,
 } from "@/components/ui/responsive-tooltip"
 
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 import { useUSDPrice } from "@/hooks/use-usd-price"
 import { useWallets } from "@/hooks/use-wallets"
 import { formatCurrencyFromString, formatNumber } from "@/lib/format"

--- a/app/trade/[base]/components/new-order/deposit-warning.tsx
+++ b/app/trade/[base]/components/new-order/deposit-warning.tsx
@@ -1,4 +1,3 @@
-import { useBackOfQueueWallet } from "@renegade-fi/react"
 import { AlertTriangle } from "lucide-react"
 
 import {
@@ -7,6 +6,7 @@ import {
   ResponsiveTooltipTrigger,
 } from "@/components/ui/responsive-tooltip"
 
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { ORDER_FORM_DEPOSIT_WARNING } from "@/lib/constants/tooltips"
 import { resolveAddress } from "@/lib/token"

--- a/app/trade/[base]/components/new-order/new-order-form.tsx
+++ b/app/trade/[base]/components/new-order/new-order-form.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useBackOfQueueWallet } from "@renegade-fi/react"
 import { ArrowRightLeft, ChevronDown } from "lucide-react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
@@ -35,6 +34,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 import { useNeedsSwitch } from "@/hooks/use-needs-switch"
 import { useOrderValue } from "@/hooks/use-order-value"
 import { usePredictedFees } from "@/hooks/use-predicted-fees"

--- a/app/trade/[base]/components/new-order/use-is-max-orders.ts
+++ b/app/trade/[base]/components/new-order/use-is-max-orders.ts
@@ -1,5 +1,6 @@
-import { useBackOfQueueWallet } from "@renegade-fi/react"
 import { MAX_ORDERS } from "@renegade-fi/react/constants"
+
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 
 export function useIsMaxOrders() {
   const { data } = useBackOfQueueWallet({

--- a/components/dialogs/order-stepper/desktop/steps/success-without-savings.tsx
+++ b/components/dialogs/order-stepper/desktop/steps/success-without-savings.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden"
-import { TaskState, useTaskHistoryWebSocket } from "@renegade-fi/react"
+import { TaskState } from "@renegade-fi/react"
 import { AlertCircle, Check, Loader2 } from "lucide-react"
 
 import { useStepper } from "@/components/dialogs/order-stepper/desktop/new-order-stepper"
@@ -15,6 +15,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+
+import { useTaskHistoryWebSocket } from "@/hooks/use-task-history-websocket"
 
 const states: TaskState[] = [
   "Proving",

--- a/components/dialogs/order-stepper/mobile/steps/success-without-savings.tsx
+++ b/components/dialogs/order-stepper/mobile/steps/success-without-savings.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden"
-import { TaskState, useTaskHistoryWebSocket } from "@renegade-fi/react"
+import { TaskState } from "@renegade-fi/react"
 import { AlertCircle, Check, Loader2 } from "lucide-react"
 
 import { useStepper } from "@/components/dialogs/order-stepper/mobile/new-order-stepper"
@@ -15,6 +15,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+
+import { useTaskHistoryWebSocket } from "@/hooks/use-task-history-websocket"
 
 const states: TaskState[] = [
   "Proving",

--- a/components/dialogs/token-select-dialog.tsx
+++ b/components/dialogs/token-select-dialog.tsx
@@ -2,7 +2,6 @@ import * as React from "react"
 
 import Link from "next/link"
 
-import { useBackOfQueueWallet } from "@renegade-fi/react"
 import { Star } from "lucide-react"
 import { useDebounceValue } from "usehooks-ts"
 import { fromHex } from "viem/utils"
@@ -23,6 +22,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { formatNumber } from "@/lib/format"
 import { DISPLAY_TOKENS } from "@/lib/token"

--- a/components/dialogs/token-select.tsx
+++ b/components/dialogs/token-select.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 
 import { CaretSortIcon, CheckIcon } from "@radix-ui/react-icons"
-import { useBackOfQueueWallet } from "@renegade-fi/react"
 import { isAddress } from "viem"
 import { useAccount } from "wagmi"
 
@@ -21,6 +20,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { useOnChainBalances } from "@/hooks/use-on-chain-balances"
 import { useRefreshOnBlock } from "@/hooks/use-refresh-on-block"

--- a/components/dialogs/transfer/default-form.tsx
+++ b/components/dialogs/transfer/default-form.tsx
@@ -62,6 +62,7 @@ import { useChainId } from "@/hooks/use-chain-id"
 import { useChainName } from "@/hooks/use-chain-name"
 import { useCheckChain } from "@/hooks/use-check-chain"
 import { useDeposit } from "@/hooks/use-deposit"
+import { useIsBase } from "@/hooks/use-is-base"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { useTransactionConfirmation } from "@/hooks/use-transaction-confirmation"
 import { useWaitForTask } from "@/hooks/use-wait-for-task"
@@ -102,6 +103,7 @@ export function DefaultForm({
   const { setSide } = useServerStore((state) => state)
   const [currentStep, setCurrentStep] = React.useState(0)
   const [steps, setSteps] = React.useState<string[]>([])
+  const isBase = useIsBase()
   const isDeposit = direction === ExternalTransferDirection.Deposit
 
   const amount = useWatch({
@@ -565,7 +567,11 @@ export function DefaultForm({
 
             <div
               className={cn("flex justify-between", {
-                hidden: !userHasL1Balance || !isDeposit || !l1Token?.address,
+                hidden:
+                  !userHasL1Balance ||
+                  !isDeposit ||
+                  !l1Token?.address ||
+                  isBase,
               })}
             >
               <div className="flex items-center gap-1 text-sm text-muted-foreground">
@@ -607,7 +613,11 @@ export function DefaultForm({
 
             <div
               className={cn({
-                hidden: !userHasL1Balance || !isDeposit || !l1Token?.address,
+                hidden:
+                  !userHasL1Balance ||
+                  !isDeposit ||
+                  !l1Token?.address ||
+                  isBase,
               })}
             >
               <BridgePrompt

--- a/components/dialogs/transfer/hooks/use-renegade-balance.tsx
+++ b/components/dialogs/transfer/hooks/use-renegade-balance.tsx
@@ -1,8 +1,8 @@
-import { useBackOfQueueWallet } from "@renegade-fi/react"
 import { formatUnits, isAddress } from "viem/utils"
 
 import { useToken } from "@/components/dialogs/transfer/hooks/use-token"
 
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 import { formatNumber } from "@/lib/format"
 
 export function useRenegadeBalance(mint: string) {

--- a/components/dialogs/transfer/transfer-dialog.tsx
+++ b/components/dialogs/transfer/transfer-dialog.tsx
@@ -1,12 +1,13 @@
 import * as React from "react"
 
-import { useBackOfQueueWallet, usePayFees } from "@renegade-fi/react"
+import { usePayFees } from "@renegade-fi/react"
 
 import { Header } from "@/components/dialogs/transfer/header"
 import { ExternalTransferDirection } from "@/components/dialogs/transfer/helpers"
 import { TransferForm } from "@/components/dialogs/transfer/transfer-form"
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
 
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 import { useFeeOnZeroBalance } from "@/hooks/use-fee-on-zero-balance"
 import { useMediaQuery } from "@/hooks/use-media-query"
 

--- a/components/dialogs/transfer/use-is-max-balances.ts
+++ b/components/dialogs/transfer/use-is-max-balances.ts
@@ -1,5 +1,6 @@
-import { useBackOfQueueWallet } from "@renegade-fi/react"
 import { MAX_BALANCES } from "@renegade-fi/react/constants"
+
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 
 export function useIsMaxBalances(mint?: string) {
   const { data } = useBackOfQueueWallet({

--- a/hooks/query/use-back-of-queue-wallet.ts
+++ b/hooks/query/use-back-of-queue-wallet.ts
@@ -1,0 +1,65 @@
+import { useWalletWebsocket } from "@renegade-fi/react"
+import {
+  getBackOfQueueWallet,
+  GetBackOfQueueWalletReturnType,
+} from "@renegade-fi/react/actions"
+import {
+  QueryKey,
+  useQuery,
+  useQueryClient,
+  UseQueryOptions,
+} from "@tanstack/react-query"
+
+import { getConfig } from "@/providers/renegade-provider/config"
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
+
+import { WalletData } from "./utils"
+
+export function walletQueryKey(options: WalletData) {
+  return [
+    "backOfQueueWallet",
+    {
+      scopeKey: options.id,
+    },
+  ] as QueryKey
+}
+
+export function useBackOfQueueWallet<
+  TData = GetBackOfQueueWalletReturnType,
+>(options?: {
+  query?: Partial<UseQueryOptions<GetBackOfQueueWalletReturnType, Error, TData>>
+}) {
+  const queryClient = useQueryClient()
+  const cachedWallet = useServerStore((state) => state.wallet)
+  const queryKey = walletQueryKey(cachedWallet)
+  const enabled = Boolean(
+    cachedWallet.seed && cachedWallet.chainId && cachedWallet.id,
+  )
+
+  useWalletWebsocket({
+    seed: cachedWallet.seed,
+    walletId: cachedWallet.id,
+    chainId: cachedWallet.chainId,
+    onUpdate: (wallet) => {
+      if (wallet && queryClient && queryKey) {
+        queryClient.setQueryData(queryKey, wallet)
+      }
+    },
+  })
+
+  return useQuery<GetBackOfQueueWalletReturnType, Error, TData>({
+    queryKey,
+    queryFn: async () => {
+      if (!cachedWallet.seed || !cachedWallet.chainId || !cachedWallet.id)
+        throw new Error("Wallet not found")
+      const config = getConfig({
+        seed: cachedWallet.seed,
+        chainId: cachedWallet.chainId,
+        id: cachedWallet.id,
+      })
+      return getBackOfQueueWallet(config)
+    },
+    enabled,
+    ...options?.query,
+  })
+}

--- a/hooks/query/useLocalConfig.ts
+++ b/hooks/query/useLocalConfig.ts
@@ -1,0 +1,19 @@
+import { useMemo } from "react"
+
+import { createConfig, getSDKConfig } from "@renegade-fi/react"
+
+/** Constructs a config given chain id and seed. */
+export function useLocalConfig(chainId?: number, seed?: `0x${string}`) {
+  return useMemo(() => {
+    if (!chainId) return
+    const configv2 = getSDKConfig(chainId)
+    const config = createConfig({
+      darkPoolAddress: configv2.darkpoolAddress,
+      priceReporterUrl: configv2.priceReporterUrl,
+      relayerUrl: configv2.relayerUrl,
+      chainId: configv2.id,
+    })
+    config.setState((s) => ({ ...s, seed, status: "in relayer" }))
+    return config
+  }, [chainId, seed])
+}

--- a/hooks/query/utils.ts
+++ b/hooks/query/utils.ts
@@ -1,0 +1,5 @@
+export interface WalletData {
+  seed?: `0x${string}`
+  chainId?: number
+  id?: string
+}

--- a/hooks/use-assets-table-data.ts
+++ b/hooks/use-assets-table-data.ts
@@ -1,9 +1,9 @@
 import { useMemo } from "react"
 
-import { useBackOfQueueWallet } from "@renegade-fi/react"
 import { formatUnits } from "viem/utils"
 import { useAccount } from "wagmi"
 
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 import { useOnChainBalances } from "@/hooks/use-on-chain-balances"
 import { usePriceQueries } from "@/hooks/use-price-queries"
 import { amountTimesPrice } from "@/hooks/use-usd-price"

--- a/hooks/use-cancel-all-orders.ts
+++ b/hooks/use-cancel-all-orders.ts
@@ -1,5 +1,7 @@
-import { useBackOfQueueWallet, useConfig } from "@renegade-fi/react"
+import { useConfig } from "@renegade-fi/react"
 import { cancelOrder } from "@renegade-fi/react/actions"
+
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 
 export function useCancelAllOrders() {
   const config = useConfig()

--- a/hooks/use-deposit.ts
+++ b/hooks/use-deposit.ts
@@ -1,10 +1,6 @@
 import React from "react"
 
-import {
-  getSDKConfig,
-  useBackOfQueueWallet,
-  useConfig,
-} from "@renegade-fi/react"
+import { getSDKConfig, useConfig } from "@renegade-fi/react"
 import { deposit, getPkRootScalars } from "@renegade-fi/react/actions"
 import { MutationStatus } from "@tanstack/react-query"
 import { toast } from "sonner"
@@ -16,6 +12,7 @@ import { safeParseUnits } from "@/lib/format"
 import { signPermit2 } from "@/lib/permit2"
 import { resolveAddress } from "@/lib/token"
 
+import { useBackOfQueueWallet } from "./query/use-back-of-queue-wallet"
 import { useChainId } from "./use-chain-id"
 
 export function useDeposit() {

--- a/hooks/use-fee-on-zero-balance.ts
+++ b/hooks/use-fee-on-zero-balance.ts
@@ -1,4 +1,4 @@
-import { useBackOfQueueWallet } from "@renegade-fi/react"
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 
 export function useFeeOnZeroBalance() {
   const { data } = useBackOfQueueWallet({

--- a/hooks/use-is-order-undercapitalized.tsx
+++ b/hooks/use-is-order-undercapitalized.tsx
@@ -1,9 +1,10 @@
-import { useBackOfQueueWallet } from "@renegade-fi/react"
 import { formatUnits } from "viem/utils"
 
 import { useUSDPrice } from "@/hooks/use-usd-price"
 import { Side } from "@/lib/constants/protocol"
 import { resolveAddress } from "@/lib/token"
+
+import { useBackOfQueueWallet } from "./query/use-back-of-queue-wallet"
 
 export function useIsOrderUndercapitalized({
   amount,

--- a/hooks/use-order-history-websocket.ts
+++ b/hooks/use-order-history-websocket.ts
@@ -1,0 +1,23 @@
+import {
+  useOrderHistoryWebSocket as _useOrderHistoryWebSocket,
+  UseOrderHistoryWebSocketParameters as _UseOrderHistoryWebSocketParameters,
+} from "@renegade-fi/react"
+
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
+
+type UseOrderHistoryWebSocketParameters = Omit<
+  _UseOrderHistoryWebSocketParameters,
+  "seed" | "walletId" | "chainId"
+>
+
+export function useOrderHistoryWebSocket(
+  parameters: UseOrderHistoryWebSocketParameters,
+) {
+  const wallet = useServerStore((state) => state.wallet)
+  return _useOrderHistoryWebSocket({
+    seed: wallet.seed,
+    walletId: wallet.id,
+    chainId: wallet.chainId,
+    ...parameters,
+  })
+}

--- a/hooks/use-order-table-data.ts
+++ b/hooks/use-order-table-data.ts
@@ -1,12 +1,10 @@
-import {
-  OrderMetadata,
-  useBackOfQueueWallet,
-  useOrderHistory,
-} from "@renegade-fi/react"
+import { OrderMetadata, useOrderHistory } from "@renegade-fi/react"
 import { formatUnits } from "viem/utils"
 
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 import { getVWAP, syncOrdersWithWalletState } from "@/lib/order"
 import { resolveAddress } from "@/lib/token"
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
 
 export interface ExtendedOrderMetadata extends OrderMetadata {
   usdValue: number
@@ -18,7 +16,11 @@ export function useOrderTableData() {
       select: (data) => data.orders.map((order) => order.id),
     },
   })
+  const wallet = useServerStore((state) => state.wallet)
   const { data } = useOrderHistory({
+    seed: wallet.seed,
+    walletId: wallet.id,
+    chainId: wallet.chainId,
     query: {
       select: (data) => {
         const filtered = syncOrdersWithWalletState({

--- a/hooks/use-prepare-cancel-order.ts
+++ b/hooks/use-prepare-cancel-order.ts
@@ -3,11 +3,12 @@
 import {
   ConfigRequiredError,
   stringifyForWasm,
-  useBackOfQueueWallet,
   useConfig,
 } from "@renegade-fi/react"
 import { CancelOrderParameters } from "@renegade-fi/react/actions"
 import { useQuery } from "@tanstack/react-query"
+
+import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet"
 
 export type UsePrepareCancelOrderParameters = CancelOrderParameters
 

--- a/hooks/use-task-history-websocket.ts
+++ b/hooks/use-task-history-websocket.ts
@@ -1,0 +1,23 @@
+import {
+  useTaskHistoryWebSocket as _useTaskHistoryWebSocket,
+  UseTaskHistoryWebSocketParameters as _UseTaskHistoryWebSocketParameters,
+} from "@renegade-fi/react"
+
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
+
+type UseTaskHistoryWebSocketParameters = Omit<
+  _UseTaskHistoryWebSocketParameters,
+  "seed" | "walletId" | "chainId"
+>
+
+export function useTaskHistoryWebSocket(
+  parameters: UseTaskHistoryWebSocketParameters,
+) {
+  const wallet = useServerStore((state) => state.wallet)
+  return _useTaskHistoryWebSocket({
+    seed: wallet.seed,
+    walletId: wallet.id,
+    chainId: wallet.chainId,
+    ...parameters,
+  })
+}

--- a/hooks/use-wait-for-task.ts
+++ b/hooks/use-wait-for-task.ts
@@ -2,11 +2,17 @@ import React from "react"
 
 import { useTaskHistory } from "@renegade-fi/react"
 
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
+
 export function useWaitForTask(onConfirm?: () => void) {
   // TODO: Refactor useDeposit to useMutation and declaratively pass taskId from { data }
   // TODO: Then, remove manual reset
   const [taskId, setTaskId] = React.useState<string>()
+  const wallet = useServerStore((state) => state.wallet)
   const { data: status } = useTaskHistory({
+    seed: wallet.seed,
+    walletId: wallet.id,
+    chainId: wallet.chainId,
     query: {
       select: (data) => (taskId ? data.get(taskId)?.state : undefined),
       enabled: !!taskId,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@radix-ui/react-visually-hidden": "^1.1.0",
     "@renegade-fi/internal-sdk": "0.4.12",
     "@renegade-fi/price-reporter": "0.0.0-canary-20250529193905",
-    "@renegade-fi/react": "0.0.0-canary-20250602165352",
+    "@renegade-fi/react": "file:/Users/s/code/sdk/packages/react",
     "@renegade-fi/token-nextjs": "^0.1.8",
     "@renegade-fi/tradingview-charts": "0.27.6",
     "@solana/wallet-adapter-base": "^0.9.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: 0.0.0-canary-20250529193905
         version: 0.0.0-canary-20250529193905(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@renegade-fi/react':
-        specifier: 0.0.0-canary-20250602165352
-        version: 0.0.0-canary-20250602165352(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+        specifier: file:/Users/s/code/sdk/packages/react
+        version: file:../sdk/packages/react(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@renegade-fi/token-nextjs':
         specifier: ^0.1.8
         version: 0.1.8(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
@@ -2872,6 +2872,15 @@ packages:
       '@tanstack/query-core':
         optional: true
 
+  '@renegade-fi/core@file:../sdk/packages/core':
+    resolution: {directory: ../sdk/packages/core, type: directory}
+    peerDependencies:
+      '@tanstack/query-core': '>=5.0.0'
+      viem: 2.23.11
+    peerDependenciesMeta:
+      '@tanstack/query-core':
+        optional: true
+
   '@renegade-fi/internal-sdk@0.4.12':
     resolution: {integrity: sha512-/OK3Qfi5Pa62zWZ3X75R0i7jake2yqC0/hqjioD7LoC0BKok0VntOE2IBfHR+1rX31wpdfsrD+UjtOZ+MoaUAg==}
 
@@ -2881,8 +2890,8 @@ packages:
   '@renegade-fi/price-reporter@0.0.16':
     resolution: {integrity: sha512-sHWicMf2mIX3+uWl8qS5y10+BeRWTixiZtNwxav/UpP84bH8v7cZggjRIEJYzgVDW+N8UoSRo2xnN0OAo5FZFg==}
 
-  '@renegade-fi/react@0.0.0-canary-20250602165352':
-    resolution: {integrity: sha512-Jpa2GJttzbt1KGuYkv0jVLYJFJbOKv7gSqqCoaHNsSHRkxDMG1muCc4RGLFJ7Ei287A1mK+otJQt6ZZwPfAudA==}
+  '@renegade-fi/react@file:../sdk/packages/react':
+    resolution: {directory: ../sdk/packages/react, type: directory}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
@@ -11457,6 +11466,24 @@ snapshots:
       - react
       - ws
 
+  '@renegade-fi/core@file:../sdk/packages/core(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+    dependencies:
+      axios: 1.7.5
+      isows: 1.0.6(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      json-bigint: 1.0.0
+      neverthrow: 8.2.0
+      tiny-invariant: 1.3.3
+      viem: 2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28)
+      zustand: 4.5.5(@types/react@19.1.4)(react@19.1.0)
+    optionalDependencies:
+      '@tanstack/query-core': 5.45.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - debug
+      - immer
+      - react
+      - ws
+
   '@renegade-fi/internal-sdk@0.4.12(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(bufferutil@4.0.8)(react@19.1.0)(typescript@5.4.5)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(zod@3.25.28)':
     dependencies:
       '@datadog/datadog-api-client': 1.27.0
@@ -11516,9 +11543,9 @@ snapshots:
       - viem
       - ws
 
-  '@renegade-fi/react@0.0.0-canary-20250602165352(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@renegade-fi/react@file:../sdk/packages/react(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
-      '@renegade-fi/core': 0.0.0-canary-20250602165352(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@renegade-fi/core': file:../sdk/packages/core(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@tanstack/react-query': 5.45.1(react@19.1.0)
       json-bigint: 1.0.0
       react: 19.1.0
@@ -14737,8 +14764,8 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0)
       eslint-plugin-react: 7.37.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 5.0.0(eslint@8.57.0)
@@ -14760,13 +14787,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.6(supports-color@5.5.0)
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.15.1
@@ -14777,18 +14804,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -14799,7 +14826,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/providers/renegade-provider/config.ts
+++ b/providers/renegade-provider/config.ts
@@ -1,6 +1,8 @@
 import { createConfig, getSDKConfig } from "@renegade-fi/react"
 import { ChainId } from "@renegade-fi/react/constants"
 
+import { WalletData } from "@/hooks/query/utils"
+
 export const getConfigFromChainId = (chainId: ChainId) => {
   const sdkConfig = getSDKConfig(chainId)
   return createConfig({
@@ -9,4 +11,19 @@ export const getConfigFromChainId = (chainId: ChainId) => {
     priceReporterUrl: sdkConfig.priceReporterUrl,
     relayerUrl: sdkConfig.relayerUrl,
   })
+}
+
+export function getConfig({ seed, chainId, id }: WalletData) {
+  if (!chainId) throw new Error("Chain ID is required")
+  if (!seed) throw new Error("Seed is required")
+  if (!id) throw new Error("ID is required")
+  const configv2 = getSDKConfig(chainId)
+  const config = createConfig({
+    darkPoolAddress: configv2.darkpoolAddress,
+    priceReporterUrl: configv2.priceReporterUrl,
+    relayerUrl: configv2.relayerUrl,
+    chainId: configv2.id,
+  })
+  config.setState((s) => ({ ...s, seed, status: "in relayer", id, chainId }))
+  return config
 }


### PR DESCRIPTION
### Purpose
This PR fixes an issues with websocket connections not reacting to changes in the connected renegade wallet. To remedy this, we simplify data flow such that the source of truth for renegade wallet state is directly pipelined into the websocket and data fetching hooks.

This required re-implementing query hooks that were in the SDK in the frontend.

### Testing
- [ ] Tested locally
- [ ] Test in testnet