### PR TITLE
sync order form with server store

### DIFF
--- a/app/components/wallet-sidebar/index.tsx
+++ b/app/components/wallet-sidebar/index.tsx
@@ -42,9 +42,8 @@ export function WalletSidebar({
 }: React.ComponentProps<typeof Sidebar>) {
   const isPWA = useMediaQuery("(display-mode: standalone)")
   const { isMobile } = useSidebar()
-  const { handleClick, content, open, onOpenChange } = useSignInAndConnect()
-  const { solanaWallet, renegadeWallet, arbitrumWallet, walletReadyState } =
-    useWallets()
+  const { handleClick, open, onOpenChange } = useSignInAndConnect()
+  const { solanaWallet, renegadeWallet, arbitrumWallet } = useWallets()
   const chainId = useChainId()
   const isBase = useIsBase(chainId)
 
@@ -79,7 +78,7 @@ export function WalletSidebar({
           ) : (
             <ConnectWalletMenuItem
               subtitle=""
-              title="Connect Arbitrum Wallet"
+              title="Connect Wallet"
               onClick={handleClick}
             />
           )}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -121,7 +121,7 @@ export default async function RootLayout({
                   <SolanaProvider>
                     <SidebarProvider defaultOpen={defaultOpen}>
                       <TrackLastVisit />
-                      <WalletSidebarSync />
+                      {/* <WalletSidebarSync /> */}
                       <TailwindIndicator />
                       <TooltipProvider
                         delayDuration={0}

--- a/app/trade/[base]/components/new-order/new-order-form.tsx
+++ b/app/trade/[base]/components/new-order/new-order-form.tsx
@@ -98,10 +98,12 @@ export function NewOrderForm({
     defaultValues,
   })
   // Keep form in sync with server store
+  // TODO: This is an anti-pattern, we should use a single source of truth for the form (server state)
   React.useEffect(() => {
     form.setValue("isSell", side === Side.SELL)
     form.setValue("isQuoteCurrency", currency === "quote")
-  }, [form, side, currency])
+    form.setValue("base", base)
+  }, [form, side, currency, base])
 
   const isMaxOrders = useIsMaxOrders()
   const { walletReadyState } = useWallets()

--- a/components/dialogs/transfer/default-form.tsx
+++ b/components/dialogs/transfer/default-form.tsx
@@ -62,6 +62,7 @@ import { useChainId } from "@/hooks/use-chain-id"
 import { useChainName } from "@/hooks/use-chain-name"
 import { useCheckChain } from "@/hooks/use-check-chain"
 import { useDeposit } from "@/hooks/use-deposit"
+import { useIsBase } from "@/hooks/use-is-base"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { useTransactionConfirmation } from "@/hooks/use-transaction-confirmation"
 import { useWaitForTask } from "@/hooks/use-wait-for-task"
@@ -221,6 +222,7 @@ export function DefaultForm({
   }
 
   const chainName = useChainName(true /* short */)
+  const isBase = useIsBase()
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     const isAmountSufficient = checkAmount(
@@ -565,7 +567,11 @@ export function DefaultForm({
 
             <div
               className={cn("flex justify-between", {
-                hidden: !userHasL1Balance || !isDeposit || !l1Token?.address,
+                hidden:
+                  !userHasL1Balance ||
+                  !isDeposit ||
+                  !l1Token?.address ||
+                  isBase,
               })}
             >
               <div className="flex items-center gap-1 text-sm text-muted-foreground">
@@ -607,7 +613,11 @@ export function DefaultForm({
 
             <div
               className={cn({
-                hidden: !userHasL1Balance || !isDeposit || !l1Token?.address,
+                hidden:
+                  !userHasL1Balance ||
+                  !isDeposit ||
+                  !l1Token?.address ||
+                  isBase,
               })}
             >
               <BridgePrompt

--- a/hooks/use-wallets.ts
+++ b/hooks/use-wallets.ts
@@ -50,7 +50,7 @@ export function useWallets() {
   const renegadeWallet: Wallet =
     seed && id
       ? {
-          name: "Renegade Wallet ID",
+          name: "Renegade Wallet",
           icon: "/glyph_light.png",
           id,
           label: truncateAddress(id),
@@ -67,14 +67,14 @@ export function useWallets() {
   const arbitrumWallet: Wallet =
     address && connector
       ? {
-          name: `${chainSpecifier} Address`,
+          name: `${chainSpecifier} Wallet`,
           icon: `/${chainSpecifier}.svg`,
           id: address,
           label: ensName || truncateAddress(address),
           isConnected: true,
         }
       : {
-          name: `${chainSpecifier} Address`,
+          name: `${chainSpecifier} Wallet`,
           icon: `/${chainSpecifier}.svg`,
           id: null,
           label: "Not Connected",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@radix-ui/react-visually-hidden": "^1.1.0",
     "@renegade-fi/internal-sdk": "0.4.12",
     "@renegade-fi/price-reporter": "0.0.0-canary-20250529193905",
-    "@renegade-fi/react": "0.0.0-canary-20250602165352",
+    "@renegade-fi/react": "0.0.0-canary-20250606000526",
     "@renegade-fi/token-nextjs": "^0.1.8",
     "@renegade-fi/tradingview-charts": "0.27.6",
     "@solana/wallet-adapter-base": "^0.9.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: 0.0.0-canary-20250529193905
         version: 0.0.0-canary-20250529193905(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@renegade-fi/react':
-        specifier: 0.0.0-canary-20250602165352
-        version: 0.0.0-canary-20250602165352(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+        specifier: 0.0.0-canary-20250606000526
+        version: 0.0.0-canary-20250606000526(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@renegade-fi/token-nextjs':
         specifier: ^0.1.8
         version: 0.1.8(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
@@ -2854,6 +2854,15 @@ packages:
       '@tanstack/query-core':
         optional: true
 
+  '@renegade-fi/core@0.0.0-canary-20250606000526':
+    resolution: {integrity: sha512-cYQi576Es67E3wUENFDN5rcNCta1xLUorNHViQdF/UeXULc+bJEacQDY0TW1SHVPygnKsjrD7L4OA/9CTc9y3Q==}
+    peerDependencies:
+      '@tanstack/query-core': '>=5.0.0'
+      viem: 2.23.11
+    peerDependenciesMeta:
+      '@tanstack/query-core':
+        optional: true
+
   '@renegade-fi/core@0.9.0':
     resolution: {integrity: sha512-q3+p+x9PoQWvLL3nKPjKRDJLPlotpdvmWKhJf/7KyiIQ4nk2GUdtWfG7wxIOiwaBPAZpyoS3SXTwqBRL4aHrvw==}
     peerDependencies:
@@ -2881,8 +2890,8 @@ packages:
   '@renegade-fi/price-reporter@0.0.16':
     resolution: {integrity: sha512-sHWicMf2mIX3+uWl8qS5y10+BeRWTixiZtNwxav/UpP84bH8v7cZggjRIEJYzgVDW+N8UoSRo2xnN0OAo5FZFg==}
 
-  '@renegade-fi/react@0.0.0-canary-20250602165352':
-    resolution: {integrity: sha512-Jpa2GJttzbt1KGuYkv0jVLYJFJbOKv7gSqqCoaHNsSHRkxDMG1muCc4RGLFJ7Ei287A1mK+otJQt6ZZwPfAudA==}
+  '@renegade-fi/react@0.0.0-canary-20250606000526':
+    resolution: {integrity: sha512-AoB5Sog79bV89WzedJ0LBWyBYQE3D2uRKVuEj6d7cI3Ij3Km9oZqzxrLTAQPdZROYMkS6oSE4ROtgcHDHAGaSw==}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
@@ -11421,6 +11430,24 @@ snapshots:
       - react
       - ws
 
+  '@renegade-fi/core@0.0.0-canary-20250606000526(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+    dependencies:
+      axios: 1.7.5
+      isows: 1.0.6(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      json-bigint: 1.0.0
+      neverthrow: 8.2.0
+      tiny-invariant: 1.3.3
+      viem: 2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28)
+      zustand: 4.5.5(@types/react@19.1.4)(react@19.1.0)
+    optionalDependencies:
+      '@tanstack/query-core': 5.45.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - debug
+      - immer
+      - react
+      - ws
+
   '@renegade-fi/core@0.9.0(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       axios: 1.7.5
@@ -11516,9 +11543,9 @@ snapshots:
       - viem
       - ws
 
-  '@renegade-fi/react@0.0.0-canary-20250602165352(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@renegade-fi/react@0.0.0-canary-20250606000526(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
-      '@renegade-fi/core': 0.0.0-canary-20250602165352(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@renegade-fi/core': 0.0.0-canary-20250606000526(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@tanstack/react-query': 5.45.1(react@19.1.0)
       json-bigint: 1.0.0
       react: 19.1.0


### PR DESCRIPTION
### Purpose
This PR fixes an issue where the base mint was not being synced between the server state and the order form state.

In the future, we should remove the form entirely and instead use controlled components deriving/setting state in the server store. Using an effect to keep two pieces of state is an anti-pattern and leads to bugs exactly like this one. 

### Testing
- [ ] Tested locally
- [ ] Test in testnet