### PR TITLE
server store: add top level chain id, multiple wallets

### DIFF
--- a/app/components/chain-selector.tsx
+++ b/app/components/chain-selector.tsx
@@ -1,0 +1,101 @@
+import * as React from "react"
+
+import Image from "next/image"
+
+import { CheckIcon } from "@radix-ui/react-icons"
+import { ChainId } from "@renegade-fi/react/constants"
+import { ChevronDown } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+
+import { env } from "@/env/client"
+import { cn } from "@/lib/utils"
+import { useServerStore } from "@/providers/state-provider/server-store-provider"
+import {
+  MAINNET_CHAINS,
+  TESTNET_CHAINS,
+} from "@/providers/wagmi-provider/config"
+
+const values = (
+  env.NEXT_PUBLIC_CHAIN_ENVIRONMENT === "mainnet"
+    ? MAINNET_CHAINS
+    : TESTNET_CHAINS
+).map((chain) => ({
+  value: chain.id,
+  label: chain.name.split(" ")[0],
+  icon: `/${chain.name.split(" ")[0].toLowerCase()}.svg`,
+}))
+
+export function ChainSelector() {
+  const [open, setOpen] = React.useState(false)
+  const { chainId, setChainId } = useServerStore((s) => s)
+
+  return (
+    <Popover
+      modal
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          aria-expanded={open}
+          className="justify-between"
+          role="combobox"
+          size="default"
+          variant="outline"
+        >
+          <Image
+            alt={values.find((v) => v.value === chainId)?.label ?? ""}
+            className="mr-2 h-4 w-4 shrink-0"
+            height={16}
+            src={values.find((v) => v.value === chainId)?.icon ?? ""}
+            width={16}
+          />
+          <ChevronDown
+            className={cn(
+              "h-4 w-4 shrink-0 transition-transform duration-200 ease-in-out",
+              open && "rotate-180",
+            )}
+          />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="min-w-fit p-0">
+        <Command>
+          <CommandList>
+            <CommandGroup>
+              {values.map((v) => (
+                <CommandItem
+                  key={v.value}
+                  value={v.value.toString()}
+                  onSelect={(currentValue) => {
+                    setChainId(Number.parseInt(currentValue) as ChainId)
+                    setOpen(false)
+                  }}
+                >
+                  <span className="flex-1">{v.label}</span>
+                  <CheckIcon
+                    className={cn(
+                      "ml-auto h-4 w-4",
+                      chainId === v.value ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -26,6 +26,8 @@ import { resolveAddress } from "@/lib/token"
 import { cn } from "@/lib/utils"
 import { useServerStore } from "@/providers/state-provider/server-store-provider"
 
+import { ChainSelector } from "./chain-selector"
+
 export function Header() {
   const pathname = usePathname()
   const { walletReadyState, arbitrumWallet } = useWallets()
@@ -140,6 +142,7 @@ export function Header() {
           </Link>
         </nav>
         <div className="flex items-center space-x-4 justify-self-end">
+          <ChainSelector />
           {walletReadyState === "READY" ? (
             <>
               <TransferDialog>

--- a/app/components/wallet-sidebar/index.tsx
+++ b/app/components/wallet-sidebar/index.tsx
@@ -42,9 +42,8 @@ export function WalletSidebar({
 }: React.ComponentProps<typeof Sidebar>) {
   const isPWA = useMediaQuery("(display-mode: standalone)")
   const { isMobile } = useSidebar()
-  const { handleClick, content, open, onOpenChange } = useSignInAndConnect()
-  const { solanaWallet, renegadeWallet, arbitrumWallet, walletReadyState } =
-    useWallets()
+  const { handleClick, open, onOpenChange } = useSignInAndConnect()
+  const { solanaWallet, renegadeWallet, arbitrumWallet } = useWallets()
   const chainId = useChainId()
   const isBase = useIsBase(chainId)
 
@@ -79,7 +78,7 @@ export function WalletSidebar({
           ) : (
             <ConnectWalletMenuItem
               subtitle=""
-              title="Connect Arbitrum Wallet"
+              title="Connect Wallet"
               onClick={handleClick}
             />
           )}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -121,7 +121,7 @@ export default async function RootLayout({
                   <SolanaProvider>
                     <SidebarProvider defaultOpen={defaultOpen}>
                       <TrackLastVisit />
-                      <WalletSidebarSync />
+                      {/* <WalletSidebarSync /> */}
                       <TailwindIndicator />
                       <TooltipProvider
                         delayDuration={0}

--- a/app/trade/[base]/components/new-order/new-order-form.tsx
+++ b/app/trade/[base]/components/new-order/new-order-form.tsx
@@ -98,10 +98,12 @@ export function NewOrderForm({
     defaultValues,
   })
   // Keep form in sync with server store
+  // TODO: This is an anti-pattern, we should use a single source of truth for the form (server state)
   React.useEffect(() => {
     form.setValue("isSell", side === Side.SELL)
     form.setValue("isQuoteCurrency", currency === "quote")
-  }, [form, side, currency])
+    form.setValue("base", base)
+  }, [form, side, currency, base])
 
   const isMaxOrders = useIsMaxOrders()
   const { walletReadyState } = useWallets()

--- a/components/dialogs/transfer/default-form.tsx
+++ b/components/dialogs/transfer/default-form.tsx
@@ -62,6 +62,7 @@ import { useChainId } from "@/hooks/use-chain-id"
 import { useChainName } from "@/hooks/use-chain-name"
 import { useCheckChain } from "@/hooks/use-check-chain"
 import { useDeposit } from "@/hooks/use-deposit"
+import { useIsBase } from "@/hooks/use-is-base"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { useTransactionConfirmation } from "@/hooks/use-transaction-confirmation"
 import { useWaitForTask } from "@/hooks/use-wait-for-task"
@@ -221,6 +222,7 @@ export function DefaultForm({
   }
 
   const chainName = useChainName(true /* short */)
+  const isBase = useIsBase()
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     const isAmountSufficient = checkAmount(
@@ -565,7 +567,11 @@ export function DefaultForm({
 
             <div
               className={cn("flex justify-between", {
-                hidden: !userHasL1Balance || !isDeposit || !l1Token?.address,
+                hidden:
+                  !userHasL1Balance ||
+                  !isDeposit ||
+                  !l1Token?.address ||
+                  isBase,
               })}
             >
               <div className="flex items-center gap-1 text-sm text-muted-foreground">
@@ -607,7 +613,11 @@ export function DefaultForm({
 
             <div
               className={cn({
-                hidden: !userHasL1Balance || !isDeposit || !l1Token?.address,
+                hidden:
+                  !userHasL1Balance ||
+                  !isDeposit ||
+                  !l1Token?.address ||
+                  isBase,
               })}
             >
               <BridgePrompt

--- a/env/schema.ts
+++ b/env/schema.ts
@@ -5,13 +5,22 @@ import z from "zod/v4"
 export const zHexString = z.templateLiteral(["0x", z.string()])
 
 /** Dynamically create chain ID literals from CHAIN_IDS */
-const chainIdValues = Object.values(CHAIN_IDS)
+export const chainIdValues = Object.values(CHAIN_IDS)
 const chainIdLiterals = chainIdValues.map((id) => z.literal(id)) as [
   ...z.ZodLiteral<(typeof chainIdValues)[number]>[],
 ]
 
-/** Zod schema for accepted chain IDs with type narrowing to number literals */
-export const zChainId = z.coerce.number().pipe(z.union(chainIdLiterals))
+/**
+ * zChainIdKey: a raw union of numeric chain-ID literals.
+ * Used as a "pure" key schema in z.record(...) (Zod requires literal schemas here).
+ */
+export const zChainIdKey = z.union(chainIdLiterals)
+
+/**
+ * zChainId: coercing schema for external inputs (env vars, JSON, etc.).
+ * Coerces strings → numbers, then validates against our literal set.
+ */
+export const zChainId = z.coerce.number().pipe(zChainIdKey)
 
 /** Zod schema for JSON strings */
 export const zJsonString = z.string().transform((str, ctx): z.ZodJSONSchema => {

--- a/hooks/use-wallets.ts
+++ b/hooks/use-wallets.ts
@@ -50,7 +50,7 @@ export function useWallets() {
   const renegadeWallet: Wallet =
     seed && id
       ? {
-          name: "Renegade Wallet ID",
+          name: "Renegade Wallet",
           icon: "/glyph_light.png",
           id,
           label: truncateAddress(id),
@@ -67,14 +67,14 @@ export function useWallets() {
   const arbitrumWallet: Wallet =
     address && connector
       ? {
-          name: `${chainSpecifier} Address`,
+          name: `${chainSpecifier} Wallet`,
           icon: `/${chainSpecifier}.svg`,
           id: address,
           label: ensName || truncateAddress(address),
           isConnected: true,
         }
       : {
-          name: `${chainSpecifier} Address`,
+          name: `${chainSpecifier} Wallet`,
           icon: `/${chainSpecifier}.svg`,
           id: null,
           label: "Not Connected",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@radix-ui/react-visually-hidden": "^1.1.0",
     "@renegade-fi/internal-sdk": "0.4.12",
     "@renegade-fi/price-reporter": "0.0.0-canary-20250529193905",
-    "@renegade-fi/react": "0.0.0-canary-20250602165352",
+    "@renegade-fi/react": "0.0.0-canary-20250606000526",
     "@renegade-fi/token-nextjs": "^0.1.8",
     "@renegade-fi/tradingview-charts": "0.27.6",
     "@solana/wallet-adapter-base": "^0.9.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: 0.0.0-canary-20250529193905
         version: 0.0.0-canary-20250529193905(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@renegade-fi/react':
-        specifier: 0.0.0-canary-20250602165352
-        version: 0.0.0-canary-20250602165352(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+        specifier: 0.0.0-canary-20250606000526
+        version: 0.0.0-canary-20250606000526(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@renegade-fi/token-nextjs':
         specifier: ^0.1.8
         version: 0.1.8(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
@@ -2854,6 +2854,15 @@ packages:
       '@tanstack/query-core':
         optional: true
 
+  '@renegade-fi/core@0.0.0-canary-20250606000526':
+    resolution: {integrity: sha512-cYQi576Es67E3wUENFDN5rcNCta1xLUorNHViQdF/UeXULc+bJEacQDY0TW1SHVPygnKsjrD7L4OA/9CTc9y3Q==}
+    peerDependencies:
+      '@tanstack/query-core': '>=5.0.0'
+      viem: 2.23.11
+    peerDependenciesMeta:
+      '@tanstack/query-core':
+        optional: true
+
   '@renegade-fi/core@0.9.0':
     resolution: {integrity: sha512-q3+p+x9PoQWvLL3nKPjKRDJLPlotpdvmWKhJf/7KyiIQ4nk2GUdtWfG7wxIOiwaBPAZpyoS3SXTwqBRL4aHrvw==}
     peerDependencies:
@@ -2881,8 +2890,8 @@ packages:
   '@renegade-fi/price-reporter@0.0.16':
     resolution: {integrity: sha512-sHWicMf2mIX3+uWl8qS5y10+BeRWTixiZtNwxav/UpP84bH8v7cZggjRIEJYzgVDW+N8UoSRo2xnN0OAo5FZFg==}
 
-  '@renegade-fi/react@0.0.0-canary-20250602165352':
-    resolution: {integrity: sha512-Jpa2GJttzbt1KGuYkv0jVLYJFJbOKv7gSqqCoaHNsSHRkxDMG1muCc4RGLFJ7Ei287A1mK+otJQt6ZZwPfAudA==}
+  '@renegade-fi/react@0.0.0-canary-20250606000526':
+    resolution: {integrity: sha512-AoB5Sog79bV89WzedJ0LBWyBYQE3D2uRKVuEj6d7cI3Ij3Km9oZqzxrLTAQPdZROYMkS6oSE4ROtgcHDHAGaSw==}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
@@ -11421,6 +11430,24 @@ snapshots:
       - react
       - ws
 
+  '@renegade-fi/core@0.0.0-canary-20250606000526(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+    dependencies:
+      axios: 1.7.5
+      isows: 1.0.6(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      json-bigint: 1.0.0
+      neverthrow: 8.2.0
+      tiny-invariant: 1.3.3
+      viem: 2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28)
+      zustand: 4.5.5(@types/react@19.1.4)(react@19.1.0)
+    optionalDependencies:
+      '@tanstack/query-core': 5.45.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - debug
+      - immer
+      - react
+      - ws
+
   '@renegade-fi/core@0.9.0(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       axios: 1.7.5
@@ -11516,9 +11543,9 @@ snapshots:
       - viem
       - ws
 
-  '@renegade-fi/react@0.0.0-canary-20250602165352(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@renegade-fi/react@0.0.0-canary-20250606000526(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@19.1.0))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
-      '@renegade-fi/core': 0.0.0-canary-20250602165352(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@renegade-fi/core': 0.0.0-canary-20250606000526(@tanstack/query-core@5.45.0)(@types/react@19.1.4)(react@19.1.0)(viem@2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28))(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@tanstack/react-query': 5.45.1(react@19.1.0)
       json-bigint: 1.0.0
       react: 19.1.0

--- a/providers/state-provider/cookie-storage.ts
+++ b/providers/state-provider/cookie-storage.ts
@@ -1,4 +1,3 @@
-import { deserialize, parseCookie } from "wagmi"
 import { StateStorage } from "zustand/middleware"
 
 import {
@@ -37,9 +36,21 @@ export const createCookieStorage = (): StateStorage => {
   }
 }
 
+export function parseCookie(cookie: string, key: string) {
+  const keyValue = cookie.split("; ").find((x) => x.startsWith(`${key}=`))
+  if (!keyValue) return undefined
+  return keyValue.substring(key.length + 1)
+}
+
 export function cookieToInitialState(key: string, cookie?: string | null) {
   if (!cookie) return undefined
   const parsed = parseCookie(decodeURIComponent(cookie), key)
   if (!parsed) return undefined
-  return deserialize<{ state: ServerState }>(parsed).state
+  try {
+    const { state } = JSON.parse(parsed) as { state: ServerState }
+    return state
+  } catch (err) {
+    console.error("Error parsing cookie:", err)
+    return undefined
+  }
 }

--- a/providers/state-provider/hooks.ts
+++ b/providers/state-provider/hooks.ts
@@ -1,0 +1,27 @@
+import { ChainId } from "@renegade-fi/react/constants"
+
+import { CachedWallet, createEmptyWallet } from "./schema"
+import { useServerStore } from "./server-store-provider"
+
+/**
+ * Returns the active chain ID from server state.
+ */
+export function useCurrentChain(): ChainId {
+  return useServerStore((s) => s.chainId)
+}
+
+/**
+ * Returns the wallet entry (seed & id) for the active chain.
+ */
+export function useCurrentWallet(): CachedWallet {
+  const chain = useCurrentChain()
+  return useServerStore((s) => s.wallet[chain] ?? createEmptyWallet())
+}
+
+/**
+ * Returns true if both seed and id are present for the active chain.
+ */
+export function useIsWalletConnected(): boolean {
+  const { seed, id } = useCurrentWallet()
+  return Boolean(seed && id)
+}

--- a/providers/state-provider/schema.ts
+++ b/providers/state-provider/schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod/v4"
 
-import { zChainId, zHexString } from "@/env/schema"
+import { zChainId, zChainIdKey, zHexString } from "@/env/schema"
 
 /** Zod schema for accepted sides */
 export const zSide = z.enum(["buy", "sell"])
@@ -8,12 +8,22 @@ export const zSide = z.enum(["buy", "sell"])
 /** Zod schema for accepted currencies */
 export const zCurrency = z.enum(["base", "quote"])
 
+// --- Wallet --- //
+
+export const zWallet = z.object({
+  seed: zHexString.optional(),
+  id: z.string().optional(),
+})
+
+export type CachedWallet = z.infer<typeof zWallet>
+
+export const createEmptyWallet = (): CachedWallet => zWallet.parse({})
+
+// --- Server State --- //
+
 export const ServerStateSchema = z.object({
-  wallet: z.object({
-    seed: zHexString.optional(),
-    chainId: zChainId.optional(),
-    id: z.string().optional(),
-  }),
+  chainId: zChainId,
+  wallet: z.record(zChainIdKey, zWallet),
   order: z.object({
     side: zSide,
     amount: z.string(),


### PR DESCRIPTION
### Purpose
This PR adds a top level chain id to the server store type which will be used as the source of truth of chain id throughout the app. 

This change is motivated by the desire to seamlessly switch between wallets based on chain id. We need to store a {seed, id} combo for each chain id, along with the current chain id the user has selected. 

### Testing
- [ ] Tested locally