### PR TITLE
cancel order: use reactive hook

### DIFF
--- a/app/components/wallet-sidebar/renegade-wallet-actions-dropdown.tsx
+++ b/app/components/wallet-sidebar/renegade-wallet-actions-dropdown.tsx
@@ -11,8 +11,8 @@ import {
 import { Label } from "@/components/ui/label"
 
 import { type Wallet } from "@/hooks/use-wallets"
-import { useConfig } from "@/providers/renegade-provider/config-provider"
 import { useClientStore } from "@/providers/state-provider/client-store-provider.tsx"
+import { useConfig } from "@/providers/state-provider/hooks"
 import { useServerStore } from "@/providers/state-provider/server-store-provider"
 
 interface RenegadeWalletActionsDropdownProps {

--- a/app/components/wallet-sidebar/renegade-wallet-actions-dropdown.tsx
+++ b/app/components/wallet-sidebar/renegade-wallet-actions-dropdown.tsx
@@ -1,4 +1,3 @@
-import { useConfig } from "@renegade-fi/react"
 import { refreshWallet } from "@renegade-fi/react/actions"
 import { Clipboard, RefreshCw, SquareX, UserCheck } from "lucide-react"
 
@@ -12,6 +11,7 @@ import {
 import { Label } from "@/components/ui/label"
 
 import { type Wallet } from "@/hooks/use-wallets"
+import { useConfig } from "@/providers/renegade-provider/config-provider"
 import { useClientStore } from "@/providers/state-provider/client-store-provider.tsx"
 import { useServerStore } from "@/providers/state-provider/server-store-provider"
 

--- a/app/trade/[base]/components/order-details/cancel-button.tsx
+++ b/app/trade/[base]/components/order-details/cancel-button.tsx
@@ -1,10 +1,11 @@
-import { UpdateType, useCancelOrder } from "@renegade-fi/react"
+import { UpdateType } from "@renegade-fi/react"
 import { Loader2 } from "lucide-react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import { MaintenanceButtonWrapper } from "@/components/ui/maintenance-button-wrapper"
 
+import { useCancelOrder } from "@/hooks/mutation/use-cancel-order"
 import { usePrepareCancelOrder } from "@/hooks/use-prepare-cancel-order"
 import { constructStartToastMessage } from "@/lib/constants/task"
 import { cn } from "@/lib/utils"
@@ -19,7 +20,7 @@ export function CancelButton({
   isDisabled?: boolean
 }) {
   const { data: request } = usePrepareCancelOrder({ id })
-  const { cancelOrder } = useCancelOrder()
+  const { mutate: cancelOrder } = useCancelOrder()
 
   return (
     <MaintenanceButtonWrapper

--- a/components/dialogs/order-stepper/mobile/steps/confirm.tsx
+++ b/components/dialogs/order-stepper/mobile/steps/confirm.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-import { UpdateType, useCreateOrder } from "@renegade-fi/react"
+import { UpdateType } from "@renegade-fi/react"
 import { Loader2 } from "lucide-react"
 import { toast } from "sonner"
 
@@ -15,6 +15,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 
+import { useCreateOrder } from "@/hooks/mutation/use-create-order"
 import { usePrepareCreateOrder } from "@/hooks/use-prepare-create-order"
 import { usePriceQuery } from "@/hooks/use-price-query"
 import { constructStartToastMessage } from "@/lib/constants/task"
@@ -46,7 +47,7 @@ export function ConfirmStep(props: NewOrderConfirmationProps) {
     allowExternalMatches,
   })
 
-  const { createOrder } = useCreateOrder({
+  const { mutate: createOrder } = useCreateOrder({
     mutation: {
       onSuccess(data) {
         props.onSuccess?.()

--- a/components/wallet-index-check.tsx
+++ b/components/wallet-index-check.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useId } from "react"
 
-import { ConfigRequiredError, useConfig } from "@renegade-fi/react"
+import { ConfigRequiredError } from "@renegade-fi/react"
 import {
   createWallet,
   getWalletFromRelayer,
@@ -12,6 +12,7 @@ import { useMutation } from "@tanstack/react-query"
 import { Loader2 } from "lucide-react"
 import { toast } from "sonner"
 
+import { useConfig } from "@/providers/renegade-provider/config-provider"
 import {
   useCurrentChain,
   useCurrentWallet,

--- a/components/wallet-index-check.tsx
+++ b/components/wallet-index-check.tsx
@@ -12,7 +12,7 @@ import { useMutation } from "@tanstack/react-query"
 import { Loader2 } from "lucide-react"
 import { toast } from "sonner"
 
-import { useConfig } from "@/providers/renegade-provider/config-provider"
+import { useConfig } from "@/providers/state-provider/hooks"
 import {
   useCurrentChain,
   useCurrentWallet,

--- a/hooks/mutation/use-cancel-order.ts
+++ b/hooks/mutation/use-cancel-order.ts
@@ -1,0 +1,32 @@
+import {
+  CancelOrderRequestParameters,
+  CancelOrderRequestReturnType,
+  cancelOrderRequest,
+} from "@renegade-fi/react/actions"
+import { useMutation, UseMutationOptions } from "@tanstack/react-query"
+
+import { useConfig } from "@/providers/renegade-provider/config-provider"
+
+export function useCancelOrder(parameters?: {
+  mutation?: Partial<
+    UseMutationOptions<
+      CancelOrderRequestReturnType,
+      Error,
+      CancelOrderRequestParameters
+    >
+  >
+}) {
+  const config = useConfig()
+  return useMutation<
+    CancelOrderRequestReturnType,
+    Error,
+    CancelOrderRequestParameters
+  >({
+    mutationKey: ["cancel-order"],
+    mutationFn: async (variables) => {
+      if (!config) throw new Error("No wallet found in storage")
+      return cancelOrderRequest(config, variables)
+    },
+    ...parameters?.mutation,
+  })
+}

--- a/hooks/mutation/use-cancel-order.ts
+++ b/hooks/mutation/use-cancel-order.ts
@@ -5,7 +5,7 @@ import {
 } from "@renegade-fi/react/actions"
 import { useMutation, UseMutationOptions } from "@tanstack/react-query"
 
-import { useConfig } from "@/providers/renegade-provider/config-provider"
+import { useConfig } from "@/providers/state-provider/hooks"
 
 export function useCancelOrder(parameters?: {
   mutation?: Partial<

--- a/providers/state-provider/hooks.ts
+++ b/providers/state-provider/hooks.ts
@@ -5,6 +5,7 @@ import { useMemo } from "react"
 import { ChainId } from "@renegade-fi/react/constants"
 
 import { getConfigFromChainId } from "../renegade-provider/config"
+import { useWasm } from "../renegade-provider/wasm-provider"
 import { CachedWallet, createEmptyWallet } from "./schema"
 import { useServerStore } from "./server-store-provider"
 
@@ -40,11 +41,12 @@ export function useIsWalletConnected(): boolean {
  * Importantly, this reacts to changes in the wallet and chain id.
  */
 export function useConfig() {
+  const { isInitialized } = useWasm()
   const chainId = useCurrentChain()
   const wallet = useCurrentWallet()
 
   return useMemo(() => {
-    if (!wallet.seed || !wallet.id) return
+    if (!wallet.seed || !wallet.id || !isInitialized) return
     const config = getConfigFromChainId(chainId)
     config.setState((s) => ({
       ...s,
@@ -54,5 +56,5 @@ export function useConfig() {
       status: "in relayer",
     }))
     return config
-  }, [chainId, wallet.id, wallet.seed])
+  }, [chainId, isInitialized, wallet.id, wallet.seed])
 }


### PR DESCRIPTION
### Purpose
This PR adds reactive `useCancelOrder` hook. It also completely migrates from the old useConfig hook to the new one.

### Testing
- [ ] Tested locally
- [ ] Test in testnet