### PR TITLE
storage: always use selectors

### DIFF
--- a/app/components/track-last-visit.tsx
+++ b/app/components/track-last-visit.tsx
@@ -5,7 +5,7 @@ import React from "react"
 import { useClientStore } from "@/providers/state-provider/client-store-provider"
 
 export function TrackLastVisit() {
-  const { setLastVisitTs } = useClientStore((state) => state)
+  const setLastVisitTs = useClientStore((s) => s.setLastVisitTs)
 
   React.useEffect(() => {
     const handleBeforeUnload = () => {

--- a/app/components/wallet-sidebar/hooks/use-unviewed-fills.ts
+++ b/app/components/wallet-sidebar/hooks/use-unviewed-fills.ts
@@ -13,7 +13,7 @@ import { syncOrdersWithWalletState } from "@/lib/order"
 import { useClientStore } from "@/providers/state-provider/client-store-provider"
 
 export function useRecentUnviewedFills() {
-  const { lastVisitTs } = useClientStore((state) => state)
+  const lastVisitTs = useClientStore((s) => s.lastVisitTs)
   const lastVisitBigInt = React.useMemo(
     () => (lastVisitTs ? BigInt(lastVisitTs) : null),
     [lastVisitTs],

--- a/app/components/wallet-sidebar/hooks/use-viewed-fills.ts
+++ b/app/components/wallet-sidebar/hooks/use-viewed-fills.ts
@@ -10,7 +10,8 @@ export function generateFillIdentifier(
 }
 
 export function useViewedFills() {
-  const { viewedFills, setViewedFills } = useClientStore((state) => state)
+  const viewedFills = useClientStore((s) => s.viewedFills)
+  const setViewedFills = useClientStore((s) => s.setViewedFills)
 
   const markFillAsViewed = (fillId: FillIdentifier) => {
     if (!viewedFills.includes(fillId)) {

--- a/app/trade/[base]/components/favorites-banner.tsx
+++ b/app/trade/[base]/components/favorites-banner.tsx
@@ -10,7 +10,7 @@ import { resolveAddress } from "@/lib/token"
 import { useClientStore } from "@/providers/state-provider/client-store-provider"
 
 export function FavoritesBanner() {
-  const { favorites } = useClientStore((state) => state)
+  const favorites = useClientStore((s) => s.favorites)
   if (!favorites || !favorites.length) return null
   return (
     <div className="hidden min-h-marquee overflow-hidden lg:block">

--- a/app/trade/[base]/components/new-order/new-order-form.tsx
+++ b/app/trade/[base]/components/new-order/new-order-form.tsx
@@ -78,12 +78,11 @@ export function NewOrderForm({
   closeButton?: React.ReactNode
 }) {
   // Form initializaiton
-  const {
-    order: { side, currency },
-    quoteMint,
-    setSide,
-    setCurrency,
-  } = useServerStore((state) => state)
+  const setSide = useServerStore((s) => s.setSide)
+  const setCurrency = useServerStore((s) => s.setCurrency)
+  const side = useServerStore((s) => s.order.side)
+  const currency = useServerStore((s) => s.order.currency)
+  const quoteMint = useServerStore((s) => s.quoteMint)
   const defaultValues = React.useMemo(
     () => ({
       amount: "",

--- a/app/trade/[base]/page-client.tsx
+++ b/app/trade/[base]/page-client.tsx
@@ -33,22 +33,23 @@ const PriceChartMemo = React.memo(PriceChart)
 
 export function PageClient({ base }: { base: string }) {
   const { base: baseMint, quote: quoteMint } = useResolvePair(base)
-  const data = useOrderTableData()
-  const {
-    panels,
-    setPanels,
-    baseMint: cachedBaseMint,
-    setBase,
-    setQuote,
-  } = useServerStore((state) => state)
-  const debouncedSetPanels = useDebounceCallback(setPanels, 500)
 
+  // Cache the base and quote mint in the server store
+  const cachedBaseMint = useServerStore((s) => s.baseMint)
+  const setBase = useServerStore((s) => s.setBase)
+  const setQuote = useServerStore((s) => s.setQuote)
   React.useEffect(() => {
     if (cachedBaseMint !== baseMint) {
       setBase(baseMint)
       setQuote(quoteMint)
     }
   }, [baseMint, cachedBaseMint, quoteMint, setBase, setQuote])
+
+  const panels = useServerStore((s) => s.panels)
+  const setPanels = useServerStore((s) => s.setPanels)
+  const debouncedSetPanels = useDebounceCallback(setPanels, 500)
+
+  const data = useOrderTableData()
 
   return (
     <>

--- a/components/dialogs/token-select-dialog.tsx
+++ b/components/dialogs/token-select-dialog.tsx
@@ -141,7 +141,8 @@ function TokenList({
     },
   })
 
-  const { favorites, setFavorites } = useClientStore((state) => state)
+  const favorites = useClientStore((s) => s.favorites)
+  const setFavorites = useClientStore((s) => s.setFavorites)
 
   const chainId = useCurrentChain()
   const processedTokens = React.useMemo(() => {

--- a/components/dialogs/transfer/default-form.tsx
+++ b/components/dialogs/transfer/default-form.tsx
@@ -100,7 +100,7 @@ export function DefaultForm({
   const { checkChain } = useCheckChain()
   const isDesktop = useMediaQuery("(min-width: 1024px)")
   const queryClient = useQueryClient()
-  const { setSide } = useServerStore((state) => state)
+  const setSide = useServerStore((s) => s.setSide)
   const [currentStep, setCurrentStep] = React.useState(0)
   const [steps, setSteps] = React.useState<string[]>([])
   const isDeposit = direction === ExternalTransferDirection.Deposit

--- a/components/dialogs/transfer/usdc-form.tsx
+++ b/components/dialogs/transfer/usdc-form.tsx
@@ -128,7 +128,7 @@ export function USDCForm({
   const isMaxBalances = useIsMaxBalances(USDC_L2_TOKEN.address)
   const isDesktop = useMediaQuery("(min-width: 1024px)")
   const queryClient = useQueryClient()
-  const { setSide } = useServerStore((state) => state)
+  const setSide = useServerStore((s) => s.setSide)
   // undefined network is equivalent to the Renegade chain
   const [network, setNetwork] = React.useState<number | undefined>()
   const [steps, setSteps] = React.useState<TransferStep[]>([])

--- a/components/dialogs/transfer/weth-form.tsx
+++ b/components/dialogs/transfer/weth-form.tsx
@@ -205,7 +205,7 @@ export function WETHForm({
   const wrapRequired =
     parseEther(amount) > (l2Balance ?? BigInt(0)) &&
     parseEther(amount) <= combinedBalance
-  const { setSide } = useServerStore((state) => state)
+  const setSide = useServerStore((s) => s.setSide)
 
   const catchError = (error: Error, message: string) => {
     console.error("Error in WETH form", error)

--- a/providers/state-provider/hooks.ts
+++ b/providers/state-provider/hooks.ts
@@ -3,6 +3,7 @@
 import { useMemo } from "react"
 
 import { ChainId } from "@renegade-fi/react/constants"
+import { useShallow } from "zustand/react/shallow"
 
 import { getConfigFromChainId } from "../renegade-provider/config"
 import { useWasm } from "../renegade-provider/wasm-provider"
@@ -16,13 +17,15 @@ export function useCurrentChain(): ChainId {
   return useServerStore((s) => s.chainId)
 }
 
+/** Stable reference to an empty wallet. */
+const EMPTY_WALLET = createEmptyWallet()
+
 /**
  * Returns the wallet entry (seed & id) for the active chain.
  */
-const EMPTY_WALLET = createEmptyWallet()
 export function useCurrentWallet(): CachedWallet {
   const chain = useCurrentChain()
-  return useServerStore((s) => s.wallet.get(chain) ?? EMPTY_WALLET)
+  return useServerStore(useShallow((s) => s.wallet.get(chain) ?? EMPTY_WALLET))
 }
 
 /**

--- a/providers/state-provider/server-store.ts
+++ b/providers/state-provider/server-store.ts
@@ -34,13 +34,13 @@ export type ServerActions = {
 export type ServerStore = ServerState & ServerActions
 
 const supportedChains = Object.values(CHAIN_IDS) as ChainId[]
-export const defaultWalletMap: Map<ChainId, CachedWallet> = new Map(
+const defaultWalletMap: Map<ChainId, CachedWallet> = new Map(
   supportedChains.map(
     (chainId) => [chainId, createEmptyWallet()] as [ChainId, CachedWallet],
   ),
 )
 
-export const defaultRememberMeMap: Map<ChainId, boolean> = new Map(
+const defaultRememberMeMap: Map<ChainId, boolean> = new Map(
   supportedChains.map((chainId) => [chainId, false] as [ChainId, boolean]),
 )
 


### PR DESCRIPTION
### Purpose
This PR enforces the rule of using selectors to access items in the store, rather than accessing the whole state object and restructuring. This ensure we avoid unnecessary re-renders due to React's shallow equality checker.

### Testing
- [ ] Tested locally
- [ ] Test in testnet