### PR TITLE
base: misc fixes

### DIFF
--- a/app/api/savings/helpers.ts
+++ b/app/api/savings/helpers.ts
@@ -199,12 +199,13 @@ async function fetchOrderbookSnapshot(
   const startDate = timestamp - 60000
   const endDate = timestamp + 1
 
-  const req = await amberdataRequest({
+  const req = amberdataRequest({
     route: `${AMBERDATA_ORDERBOOK_SNAPSHOTS_ROUTE}/${instrument}`,
     startDate,
     endDate,
     exchange,
   })
+  console.log("🚀 ~ req:", req.url)
 
   const res = await fetch(req)
   if (!res.ok) {
@@ -212,6 +213,7 @@ async function fetchOrderbookSnapshot(
   }
   const orderbookRes: AmberdataOrderbookSnapshotResponse = await res.json()
   if (orderbookRes.payload.data.length === 0) {
+    console.log("Error response: ", orderbookRes)
     throw new Error("Server returned empty orderbook snapshot")
   }
 
@@ -231,7 +233,7 @@ async function fetchOrderbookUpdates(
   desiredTimestamp: number,
   exchange: string,
 ): Promise<Array<AmberdataOrderbookUpdate>> {
-  const req = await amberdataRequest({
+  const req = amberdataRequest({
     route: `${AMBERDATA_ORDERBOOK_UPDATES_ROUTE}/${instrument}`,
     startDate: snapshotTimestamp,
     endDate: desiredTimestamp,
@@ -250,7 +252,7 @@ async function fetchOrderbookUpdates(
  * @param startDate - The starting timestamp for the search range, in milliseconds (inclusive)
  * @param endDate - The ending timestamp for the search range, in milliseconds (exclusive)
  */
-async function amberdataRequest({
+function amberdataRequest({
   route,
   startDate,
   endDate,
@@ -260,7 +262,7 @@ async function amberdataRequest({
   startDate: number
   endDate: number
   exchange: string
-}): Promise<Request> {
+}): Request {
   const amberdataUrl = new URL(`${AMBERDATA_BASE_URL}/${route}`)
   amberdataUrl.searchParams.set(EXCHANGE_PARAM, exchange)
   amberdataUrl.searchParams.set(TIME_FORMAT_PARAM, TIME_FORMAT)

--- a/app/api/savings/helpers.ts
+++ b/app/api/savings/helpers.ts
@@ -28,6 +28,8 @@ const START_DATE_PARAM = "startDate"
 /** The search parameter indicating the end date for the Amberdata API to use */
 const END_DATE_PARAM = "endDate"
 
+const ONE_HOUR_MS = 3600000
+
 // ---------
 // | TYPES |
 // ---------
@@ -194,10 +196,12 @@ async function fetchOrderbookSnapshot(
   exchange: string,
 ): Promise<AmberdataOrderbookSnapshot> {
   // This is to ensure that we get the most recent snapshot inclusive of the timestamp
+  const startDate = timestamp - ONE_HOUR_MS
   const endDate = timestamp + 1
   const req = amberdataRequest({
     route: `${AMBERDATA_ORDERBOOK_SNAPSHOTS_ROUTE}/${instrument}`,
     exchange,
+    startDate,
     endDate,
   })
 

--- a/app/api/savings/route.ts
+++ b/app/api/savings/route.ts
@@ -86,6 +86,7 @@ export async function POST(request: Request) {
 
     return Response.json({ savings, savingsBps })
   } catch (error) {
+    console.error("🚀 ~ POST ~ error:", error)
     return new Response(JSON.stringify({ error }), { status: 500 })
   }
 }

--- a/app/api/savings/route.ts
+++ b/app/api/savings/route.ts
@@ -86,7 +86,6 @@ export async function POST(request: Request) {
 
     return Response.json({ savings, savingsBps })
   } catch (error) {
-    console.error("🚀 ~ POST ~ error:", error)
     return new Response(JSON.stringify({ error }), { status: 500 })
   }
 }

--- a/app/stats/chain-selector.tsx
+++ b/app/stats/chain-selector.tsx
@@ -58,7 +58,7 @@ export function ChainSelector({
         >
           {chainId
             ? values.find((v) => v.value === chainId)?.label
-            : "All Networks"}
+            : "All Chains"}
           <ChevronDown
             className={cn(
               "ml-2 h-4 w-4 shrink-0 transition-transform duration-200 ease-in-out",

--- a/app/stats/charts/inflows-chart.tsx
+++ b/app/stats/charts/inflows-chart.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { useMemo } from "react"
 
 import numeral from "numeral"
 import { Bar, BarChart, CartesianGrid, XAxis } from "recharts"
@@ -26,6 +27,8 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart"
 import { Skeleton } from "@/components/ui/skeleton"
+
+import { extractSupportedChain, getFormattedChainName } from "@/lib/viem"
 
 type ChartData = {
   timestamp: string
@@ -110,15 +113,15 @@ export function InflowsChart({ chainId }: { chainId: number }) {
 
     const netFlow = last24HoursData.reduce((sum, item) => {
       if (chainId === arbitrum.id) {
-        return sum + item.arbitrumDeposits - item.arbitrumWithdrawals
+        return sum + item.arbitrumDeposits + item.arbitrumWithdrawals
       } else if (chainId === base.id) {
-        return sum + item.baseDeposits - item.baseWithdrawals
+        return sum + item.baseDeposits + item.baseWithdrawals
       }
       return (
         sum +
         item.arbitrumDeposits +
-        item.baseDeposits -
-        item.arbitrumWithdrawals -
+        item.baseDeposits +
+        item.arbitrumWithdrawals +
         item.baseWithdrawals
       )
     }, 0)
@@ -127,6 +130,12 @@ export function InflowsChart({ chainId }: { chainId: number }) {
   }, [chainId, chartData])
 
   const isSuccess = netFlowData !== null
+
+  const chainSuffix = useMemo(() => {
+    if (!chainId) return ""
+    const chain = extractSupportedChain(chainId)
+    return ` on ${getFormattedChainName(chain.id)}`
+  }, [chainId])
 
   const showOnlyArbitrum = chainId === arbitrum.id
   const showOnlyBase = chainId === base.id
@@ -142,7 +151,7 @@ export function InflowsChart({ chainId }: { chainId: number }) {
               <Skeleton className="h-10 w-40" />
             )}
           </CardTitle>
-          <CardDescription>24H Net Flow</CardDescription>
+          <CardDescription>24H Net Flow{chainSuffix}</CardDescription>
         </div>
       </CardHeader>
       <CardContent>

--- a/app/stats/charts/tvl/tvl-section.tsx
+++ b/app/stats/charts/tvl/tvl-section.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react"
+
 import {
   Card,
   CardContent,
@@ -7,7 +9,10 @@ import {
 } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 
+import { useChain } from "@/hooks/use-chain"
+import { useChainName } from "@/hooks/use-chain-name"
 import { formatCurrency } from "@/lib/format"
+import { extractSupportedChain, getFormattedChainName } from "@/lib/viem"
 
 import { useTvlData } from "../../hooks/use-tvl-data"
 import { columns } from "./columns"
@@ -25,6 +30,12 @@ export function TvlSection({ chainId }: { chainId: number }) {
     { totalTvlUsd: 0, totalBaseTvlUsd: 0, totalArbitrumTvlUsd: 0 },
   )
 
+  const chainSuffix = useMemo(() => {
+    if (!chainId) return ""
+    const chain = extractSupportedChain(chainId)
+    return ` on ${getFormattedChainName(chain.id)}`
+  }, [chainId])
+
   return (
     <Card className="w-full rounded-none">
       <CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0 sm:flex-row">
@@ -36,7 +47,7 @@ export function TvlSection({ chainId }: { chainId: number }) {
               <Skeleton className="h-10 w-40" />
             )}
           </CardTitle>
-          <CardDescription>Total Value Deposited</CardDescription>
+          <CardDescription>Total Value Deposited{chainSuffix}</CardDescription>
         </div>
       </CardHeader>
       <CardContent className="p-0">

--- a/components/dialogs/transfer/transfer-form.tsx
+++ b/components/dialogs/transfer/transfer-form.tsx
@@ -64,7 +64,10 @@ export function TransferForm({
     )
   }
   if (direction === ExternalTransferDirection.Deposit && !isBase) {
-    if (resolveAddress(form.watch("mint") as `0x${string}`).ticker === "USDC") {
+    if (
+      form.watch("mint") &&
+      resolveAddress(form.watch("mint") as `0x${string}`).ticker === "USDC"
+    ) {
       return (
         <USDCForm
           className={className}

--- a/components/dialogs/transfer/transfer-form.tsx
+++ b/components/dialogs/transfer/transfer-form.tsx
@@ -49,9 +49,10 @@ export function TransferForm({
     )
   }
 
-  const mint = form.watch("mint")
-  const token = resolveAddress(mint as `0x${string}`)
-  if (token.ticker === "WETH") {
+  if (
+    form.watch("mint") &&
+    resolveAddress(form.watch("mint") as `0x${string}`).ticker === "WETH"
+  ) {
     return (
       <WETHForm
         className={className}
@@ -63,7 +64,7 @@ export function TransferForm({
     )
   }
   if (direction === ExternalTransferDirection.Deposit && !isBase) {
-    if (token.ticker === "USDC") {
+    if (resolveAddress(form.watch("mint") as `0x${string}`).ticker === "USDC") {
       return (
         <USDCForm
           className={className}

--- a/hooks/savings/savingsQueryOptions.ts
+++ b/hooks/savings/savingsQueryOptions.ts
@@ -12,6 +12,7 @@ export type SavingsQueryVariables = {
   quoteTicker: "USDC"
   isQuoteCurrency: boolean
   renegadeFeeRate: number
+  timestamp?: number
 }
 
 /** Factory function returning query options for the savings query */

--- a/hooks/savings/use-savings-across-fills-query.ts
+++ b/hooks/savings/use-savings-across-fills-query.ts
@@ -23,6 +23,7 @@ export function useSavingsAcrossFillsQuery(order: OrderMetadata) {
         quoteTicker: "USDC",
         isQuoteCurrency: false,
         renegadeFeeRate: PROTOCOL_FEE + RELAYER_FEE,
+        timestamp: Number.parseInt(fill.price.timestamp.toString()),
       }),
       staleTime: Infinity,
       gcTime: Infinity,

--- a/hooks/savings/use-savings-query.ts
+++ b/hooks/savings/use-savings-query.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
+import { useDebounceValue } from "usehooks-ts"
 
 import type { NewOrderFormProps } from "@/app/trade/[base]/components/new-order/new-order-form"
 
@@ -11,8 +12,10 @@ export function useSavings({
   isSell,
   isQuoteCurrency,
 }: NewOrderFormProps) {
+  const [debouncedAmount] = useDebounceValue(amount, 1000)
+
   const opts = savingsQueryOptions({
-    amount,
+    amount: debouncedAmount,
     baseMint: base,
     direction: isSell ? "sell" : "buy",
     quoteTicker: "USDC",

--- a/hooks/use-predicted-fees.ts
+++ b/hooks/use-predicted-fees.ts
@@ -19,35 +19,11 @@ export function usePredictedFees(order: NewOrderFormProps) {
     res.relayerFee = parseFloat(valueInQuoteCurrency) * RELAYER_FEE
     return res
   }, [valueInQuoteCurrency])
-
-  // Amount should always be base amount (even if denominated in USDC)
   const { data: savingsData, isSuccess } = useSavings(order)
-  const [predictedSavings, setPredictedSavings] = React.useState(0)
-  const [predictedSavingsBps, setPredictedSavingsBps] = React.useState(0)
-
-  React.useEffect(() => {
-    setPredictedSavings((prev) => {
-      if (isSuccess && savingsData && prev !== savingsData.savings) {
-        return savingsData.savings
-      } else if (!order.amount) {
-        return 0
-      }
-      return prev
-    })
-
-    setPredictedSavingsBps((prev) => {
-      if (isSuccess && savingsData && prev !== savingsData.savingsBps) {
-        return savingsData.savingsBps
-      } else if (!order.amount) {
-        return 0
-      }
-      return prev
-    })
-  }, [isSuccess, order.amount, savingsData])
 
   return {
     ...feesCalculation,
-    predictedSavings,
-    predictedSavingsBps,
+    predictedSavings: isSuccess ? savingsData?.savings : 0,
+    predictedSavingsBps: isSuccess ? savingsData?.savingsBps : 0,
   }
 }

--- a/providers/wagmi-provider/wagmi-provider.tsx
+++ b/providers/wagmi-provider/wagmi-provider.tsx
@@ -35,6 +35,7 @@ interface WagmiProviderProps {
 export function WagmiProvider({ children, initialState }: WagmiProviderProps) {
   const [config] = React.useState(() => getConfig())
   const [open, setOpen] = React.useState(false)
+  const currentChainId = useCurrentChain()
 
   return (
     <Provider
@@ -48,6 +49,7 @@ export function WagmiProvider({ children, initialState }: WagmiProviderProps) {
           options={{
             hideQuestionMarkCTA: true,
             hideTooltips: true,
+            initialChainId: currentChainId,
           }}
           theme="midnight"
           onConnect={() => {


### PR DESCRIPTION
### Purpose
#### Savings
This PR slightly adjusts the way we retrieve order book snapshots: previously we would specify a minute long timeframe to retrieve the most recent order book snapshot. This would error in the scenario wherein Amberdata had a gap of order book data for the period. This would result in a savings value never being calculated. I found these data gaps to not be uncommon, no matter how much time had passed certain timeframes never yielded results. We now fetch snapshots without a time frame and rely on Amberdata to return the most recent one. We then proceed in the same way to fetch and apply the most recent order book updates. This has proven to result in savings calculations much more consistently.

#### Stats
Chart headers now reflect the current chain, if specified, both in the cumulative values and subtitles.

#### Transfer Modal
This PR fixes an issue where the app would crash when a mint was not specified in the form or props.

#### Wagmi
We set the `initialChainId` param to the cached chain ID so the user's wallet is correctly configured upon connect.