### PR TITLE
server store: add rules for migrating properly

### DIFF
--- a/lib/constants/storage.ts
+++ b/lib/constants/storage.ts
@@ -3,3 +3,6 @@ const STORAGE_PREFIX = "trade.renegade"
 export const STORAGE_STORE = `${STORAGE_PREFIX}.store`
 export const STORAGE_SERVER_STORE = `${STORAGE_PREFIX}.server-store`
 export const STORAGE_CLIENT_STORE = `${STORAGE_PREFIX}.client-store`
+
+// Storage version for schema migrations
+export const STORAGE_VERSION = 2

--- a/providers/state-provider/server-store.ts
+++ b/providers/state-provider/server-store.ts
@@ -3,7 +3,7 @@ import { persist } from "zustand/middleware"
 import { createStore } from "zustand/vanilla"
 
 import { Side } from "@/lib/constants/protocol"
-import { STORAGE_SERVER_STORE } from "@/lib/constants/storage"
+import { STORAGE_SERVER_STORE, STORAGE_VERSION } from "@/lib/constants/storage"
 import { resolveTicker } from "@/lib/token"
 import {
   cookieStorage,
@@ -72,14 +72,6 @@ export const defaultInitState: ServerState = {
 export const createServerStore = (
   initState: ServerState = defaultInitState,
 ) => {
-  // let validatedState: ServerState
-  // const validationResult = validateState(initState)
-  // if (validationResult) {
-  //   validatedState = initState
-  // } else {
-  //   validatedState = defaultInitState
-  // }
-
   return createStore<ServerStore>()(
     persist(
       (set) => ({
@@ -124,13 +116,13 @@ export const createServerStore = (
       }),
       {
         name: STORAGE_SERVER_STORE,
-        version: 2, // Current version with Map-based storage
-        migrate: (persistedState: any, version: number): ServerState => {
+        version: STORAGE_VERSION,
+        migrate: (_: any, version: number): ServerState => {
           console.log(
-            `Storage version mismatch detected. Stored: ${version}, Expected: 2`,
+            `Storage version mismatch detected. Stored: ${version}, Expected: ${STORAGE_VERSION}`,
           )
           console.log("Clearing user data and using default state")
-          return defaultInitState // Nuclear option - always return fresh state
+          return defaultInitState
         },
         skipHydration: true,
         storage: createStorage(cookieStorage),
@@ -152,12 +144,4 @@ export const createServerStore = (
       },
     ),
   )
-}
-
-/**
- * Validates the state against the schema.
- */
-function validateState(state: ServerState): boolean {
-  const validationResult = ServerStateSchema.safeParse(state)
-  return validationResult.success
 }

--- a/providers/state-provider/server-store.ts
+++ b/providers/state-provider/server-store.ts
@@ -72,18 +72,18 @@ export const defaultInitState: ServerState = {
 export const createServerStore = (
   initState: ServerState = defaultInitState,
 ) => {
-  let validatedState: ServerState
-  const validationResult = validateState(initState)
-  if (validationResult) {
-    validatedState = initState
-  } else {
-    validatedState = defaultInitState
-  }
+  // let validatedState: ServerState
+  // const validationResult = validateState(initState)
+  // if (validationResult) {
+  //   validatedState = initState
+  // } else {
+  //   validatedState = defaultInitState
+  // }
 
   return createStore<ServerStore>()(
     persist(
       (set) => ({
-        ...validatedState,
+        ...initState,
         setAmount: (amount: string) =>
           set((state) => ({ order: { ...state.order, amount } })),
         setBase: (baseMint: `0x${string}`) =>

--- a/providers/state-provider/server-store.ts
+++ b/providers/state-provider/server-store.ts
@@ -124,6 +124,14 @@ export const createServerStore = (
       }),
       {
         name: STORAGE_SERVER_STORE,
+        version: 2, // Current version with Map-based storage
+        migrate: (persistedState: any, version: number): ServerState => {
+          console.log(
+            `Storage version mismatch detected. Stored: ${version}, Expected: 2`,
+          )
+          console.log("Clearing user data and using default state")
+          return defaultInitState // Nuclear option - always return fresh state
+        },
         skipHydration: true,
         storage: createStorage(cookieStorage),
         partialize: (state) => {


### PR DESCRIPTION
### Purpose
This PR ensures safe migrations from old storage schemas by using zustand-native options `version` and `migrate` to cleanly wipe returning users' state. 

We also add a version check to `cookieToInitialState` since migrations only run on rehydration, not initial state passed in. This obviates the need for a Zod guard in `createStore`, as any initial state parsed from cookies will necessarily be either undefined or of the correct shape for the current version.

### Testing
- [x] Tested that migration works properly when switching from old server schema to new