### PR TITLE
order table: filter zero orders from wallet'

### DIFF
--- a/hooks/use-order-table-data.ts
+++ b/hooks/use-order-table-data.ts
@@ -13,7 +13,8 @@ export interface ExtendedOrderMetadata extends OrderMetadata {
 export function useOrderTableData() {
     const { data: orderIds } = useBackOfQueueWallet({
         query: {
-            select: (data) => data.orders.map((order) => order.id),
+            // Filter out orders with 0 amount
+            select: (data) => data.orders.filter((order) => order.amount).map((order) => order.id),
         },
     });
     const { data } = useOrderHistory({


### PR DESCRIPTION
### Purpose
This PR filters out zero orders from the wallet object before syncing with order history from the HSE. This ensures the scenario where the HSE contains status `Created` but the order has amount 0 is covered, as per Joey's report.