### PR TITLE
trade: preserve chain param during redirect

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,18 @@
 import { redirect } from "next/navigation";
-
+import { SEARCH_PARAM_CHAIN } from "@/lib/constants/storage";
 import { getFallbackTicker, hydrateServerState } from "./trade/[base]/utils";
 
-export default async function Page() {
+export default async function Page({
+    searchParams,
+}: {
+    searchParams: Promise<{ chain?: string }>;
+}) {
     // Hydrate server-side state from cookies
     const serverState = await hydrateServerState();
     const ticker = getFallbackTicker(serverState);
-    redirect(`/trade/${ticker}`);
+    const chain = (await searchParams).chain;
+    const redirectUrl = chain
+        ? `/trade/${ticker}?${SEARCH_PARAM_CHAIN}=${chain}`
+        : `/trade/${ticker}`;
+    redirect(redirectUrl);
 }

--- a/app/trade/[base]/page.tsx
+++ b/app/trade/[base]/page.tsx
@@ -21,7 +21,8 @@ export default async function Page({
     searchParams: Promise<{ chain?: string }>;
 }) {
     const baseTicker = (await params).base;
-    const chainName = (await searchParams).chain ?? undefined; // providers/state-provider/server-store-provider.tsx::SEARCH_PARAM_CHAIN
+    const chainName = (await searchParams).chain; // providers/state-provider/server-store-provider.tsx::SEARCH_PARAM_CHAIN
+    console.log("🚀 ~ Page ~ chainName:", chainName);
     let chainId;
     try {
         chainId = chainIdFromEnvAndName(env.NEXT_PUBLIC_CHAIN_ENVIRONMENT, chainName as any);

--- a/app/trade/page.tsx
+++ b/app/trade/page.tsx
@@ -2,9 +2,18 @@ import { redirect } from "next/navigation";
 
 import { getFallbackTicker, hydrateServerState } from "./[base]/utils";
 
-export default async function Page() {
+export default async function Page({
+    searchParams,
+}: {
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
     // Hydrate server-side state from cookies
     const serverState = await hydrateServerState();
     const ticker = getFallbackTicker(serverState);
-    redirect(`/trade/${ticker}`);
+
+    // Preserve search parameters in the redirect
+    const params = await searchParams;
+    const queryString = new URLSearchParams(params as any).toString();
+
+    redirect(queryString ? `/trade/${ticker}?${queryString}` : `/trade/${ticker}`);
 }

--- a/app/trade/page.tsx
+++ b/app/trade/page.tsx
@@ -1,19 +1,21 @@
 import { redirect } from "next/navigation";
-
+import { SEARCH_PARAM_CHAIN } from "@/lib/constants/storage";
 import { getFallbackTicker, hydrateServerState } from "./[base]/utils";
 
 export default async function Page({
     searchParams,
 }: {
-    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+    searchParams: Promise<{ chain?: string }>;
 }) {
     // Hydrate server-side state from cookies
     const serverState = await hydrateServerState();
     const ticker = getFallbackTicker(serverState);
 
-    // Preserve search parameters in the redirect
-    const params = await searchParams;
-    const queryString = new URLSearchParams(params as any).toString();
+    // Preserve chain parameter in the redirect
+    const { chain } = await searchParams;
+    const redirectUrl = chain
+        ? `/trade/${ticker}?${SEARCH_PARAM_CHAIN}=${chain}`
+        : `/trade/${ticker}`;
 
-    redirect(queryString ? `/trade/${ticker}?${queryString}` : `/trade/${ticker}`);
+    redirect(redirectUrl);
 }


### PR DESCRIPTION
### Purpose
This PR ensures search parameters are preserved upon redirect from /trade to /trade/[base]
