### PR TITLE
pnpm: upgrade and set minimumReleaseAge

### DIFF
--- a/app/api/stats/external-transfer-logs/route.ts
+++ b/app/api/stats/external-transfer-logs/route.ts
@@ -28,7 +28,10 @@ export async function GET(req: NextRequest) {
     const inflowsKey = getInflowsKey(chainId);
     const inflowsSetKey = getInflowsSetKey(chainId);
     try {
-        const intervalMs = parseInt(req.nextUrl.searchParams.get("interval") || "86400000");
+        const intervalMs = parseInt(
+            req.nextUrl.searchParams.get("interval") || "86400000",
+            10 /* radix */,
+        );
 
         const transactionHashes = await getAllSetMembers(inflowsSetKey);
 
@@ -80,7 +83,7 @@ export async function GET(req: NextRequest) {
         });
 
         const sortedBucketData = Object.values(buckets).sort(
-            (a, b) => parseInt(a.timestamp) - parseInt(b.timestamp),
+            (a, b) => parseInt(a.timestamp, 10 /* radix */) - parseInt(b.timestamp, 10 /* radix */),
         );
 
         return new Response(JSON.stringify({ data: sortedBucketData, intervalMs }), {

--- a/app/api/stats/set-historical-volume-kv/route.ts
+++ b/app/api/stats/set-historical-volume-kv/route.ts
@@ -44,9 +44,12 @@ export async function GET(req: NextRequest) {
         const ddog = new DDogClient(env.DD_API_KEY, env.DD_APP_KEY, chainSpecifier, env.DD_SERVICE);
         const { searchParams } = new URL(req.url);
         const params: SearchParams = {
-            from: parseInt(searchParams.get("from") ?? String(DEFAULT_PARAMS.from)),
-            interval: parseInt(searchParams.get("interval") ?? String(DEFAULT_PARAMS.interval)),
-            to: parseInt(searchParams.get("to") ?? String(DEFAULT_PARAMS.to)),
+            from: parseInt(searchParams.get("from") ?? String(DEFAULT_PARAMS.from), 10 /* radix */),
+            interval: parseInt(
+                searchParams.get("interval") ?? String(DEFAULT_PARAMS.interval),
+                10 /* radix */,
+            ),
+            to: parseInt(searchParams.get("to") ?? String(DEFAULT_PARAMS.to), 10 /* radix */),
         };
 
         console.log(`Parameters: ${JSON.stringify(params)}`);

--- a/app/components/chain-selector.tsx
+++ b/app/components/chain-selector.tsx
@@ -43,7 +43,7 @@ export function ChainSelector() {
      *   mismatch modals between token chain and app chain state
      */
     const handleChainSelect = (chainValue: string) => {
-        const chainId = Number.parseInt(chainValue) as ChainId;
+        const chainId = Number.parseInt(chainValue, 10 /* radix */) as ChainId;
         const isMultiChain = isAddressMultiChain(baseMint);
         const isTradePage = pathname.startsWith("/trade");
         const chainName = getFormattedChainName(chainId).toLowerCase();

--- a/app/stats/hooks/use-tvl-data.ts
+++ b/app/stats/hooks/use-tvl-data.ts
@@ -93,8 +93,16 @@ export function useTvlData(chainId: number): PricedTvl[] {
     // Collect all mint addresses we must price
     const mintAddresses = useMemo(() => {
         const set = new Set<`0x${string}`>();
-        arbTvl?.forEach((t) => set.add(t.address));
-        baseTvl?.forEach((t) => set.add(t.address));
+        if (arbTvl) {
+            for (const t of arbTvl) {
+                set.add(t.address);
+            }
+        }
+        if (baseTvl) {
+            for (const t of baseTvl) {
+                set.add(t.address);
+            }
+        }
         return [...set];
     }, [arbTvl, baseTvl]);
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
     "assist": {
         "actions": {
             "source": {
@@ -22,6 +22,7 @@
             "!.turbo",
             "!public",
             "!**/*.d.ts",
+            "!**/*.css",
             "!lib/generated.ts"
         ]
     },
@@ -48,9 +49,7 @@
             },
             "correctness": {
                 "noUnusedFunctionParameters": "off",
-                "noUnusedVariables": "off"
-            },
-            "nursery": {
+                "noUnusedVariables": "off",
                 "useUniqueElementIds": "off"
             },
             "recommended": true,

--- a/hooks/savings/use-savings-across-fills-query.ts
+++ b/hooks/savings/use-savings-across-fills-query.ts
@@ -56,7 +56,7 @@ export function useSavingsAcrossFillsQuery(order: OrderMetadata) {
                       isQuoteCurrency: false,
                       quoteTicker: "USDC",
                       renegadeFeeRate,
-                      timestamp: Number.parseInt(fill.price.timestamp.toString()),
+                      timestamp: Number.parseInt(fill.price.timestamp.toString(), 10 /* radix */),
                   }),
                   gcTime: Infinity,
                   staleTime: Infinity,

--- a/lib/amberdata.ts
+++ b/lib/amberdata.ts
@@ -38,17 +38,20 @@ export async function fetchBars({
         currentFrom = currentTo;
     }
 
-    const fetchPromises = chunks.map((chunk) => {
+    const fetchPromises = [];
+    for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i];
         const chunkUrl = new URL(url.toString());
         chunkUrl.searchParams.set("startDate", chunk.from.toString());
         chunkUrl.searchParams.set("endDate", chunk.to.toString());
-        return makeAmberApiRequest(chunkUrl);
-    });
+        fetchPromises.push(makeAmberApiRequest(chunkUrl));
+    }
 
     const responses = await Promise.all(fetchPromises);
     const bars: Bar[] = [];
     for (const response of responses) {
-        response.payload.data.map((res: any) => {
+        for (let i = 0; i < response.payload.data.length; i++) {
+            const res = response.payload.data[i];
             const bar: Bar = {
                 close: res.close,
                 high: res.high,
@@ -58,7 +61,7 @@ export async function fetchBars({
                 volume: res.volume,
             };
             bars.push(bar);
-        });
+        }
     }
     return bars;
 }

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -18,7 +18,7 @@ const precisionFormatter = new Intl.NumberFormat("en", {
     maximumFractionDigits: 2,
     maximumSignificantDigits: 2,
     notation: "standard",
-    // @ts-ignore
+    // @ts-expect-error
     roundingPriority: "morePrecision",
     useGrouping: false,
 });
@@ -27,7 +27,7 @@ const longPrecisionFormatter = new Intl.NumberFormat("en", {
     maximumFractionDigits: 4,
     maximumSignificantDigits: 4,
     notation: "standard",
-    // @ts-ignore
+    // @ts-expect-error
     roundingPriority: "morePrecision",
     useGrouping: false,
 });

--- a/package.json
+++ b/package.json
@@ -85,8 +85,9 @@
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
     },
+    "minimumReleaseAge": 1440,
     "name": "renegade-trade",
-    "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee",
+    "packageManager": "pnpm@10.17.1+sha512.17c560fca4867ae9473a3899ad84a88334914f379be46d455cbf92e5cf4b39d34985d452d2583baf19967fa76cb5c17bc9e245529d0b98745721aa7200ecaf7a",
     "pnpm": {
         "overrides": {
             "@types/react": "19.1.4",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "zustand": "^5.0.5"
     },
     "devDependencies": {
-        "@biomejs/biome": "2.0.0",
+        "@biomejs/biome": "2.2.4",
         "@tanstack/react-query-devtools": "5.29.2",
         "@types/json-bigint": "^1.0.4",
         "@types/node": "^20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  react-is: 19.1.0
-  viem: 2.23.11
   '@types/react': 19.1.4
   '@types/react-dom': 19.1.5
+  react-is: 19.1.0
+  viem: 2.23.11
 
 importers:
 
@@ -118,7 +118,7 @@ importers:
         version: 0.9.23(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-react':
         specifier: ^0.15.35
-        version: 0.15.35(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bs58@5.0.0)(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@19.1.4)(bufferutil@4.0.8)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+        version: 0.15.35(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bs58@6.0.0)(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@19.1.4)(bufferutil@4.0.8)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       '@solana/web3.js':
         specifier: 1.95.4
         version: 1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -9552,11 +9552,11 @@ snapshots:
       '@wallet-standard/features': 1.0.3
       eventemitter3: 4.0.7
 
-  '@solana/wallet-adapter-react@0.15.35(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bs58@5.0.0)(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@19.1.4)(bufferutil@4.0.8)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)':
+  '@solana/wallet-adapter-react@0.15.35(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bs58@6.0.0)(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@19.1.4)(bufferutil@4.0.8)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)':
     dependencies:
       '@solana-mobile/wallet-adapter-mobile': 2.1.4(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@19.1.4)(bufferutil@4.0.8)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      '@solana/wallet-standard-wallet-adapter-react': 1.1.2(@solana/wallet-adapter-base@0.9.23(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@19.1.0)
+      '@solana/wallet-standard-wallet-adapter-react': 1.1.2(@solana/wallet-adapter-base@0.9.23(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@19.1.0)
       '@solana/web3.js': 1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       react: 19.1.0
     transitivePeerDependencies:
@@ -9597,10 +9597,34 @@ snapshots:
       '@wallet-standard/wallet': 1.0.1
       bs58: 5.0.0
 
+  '@solana/wallet-standard-wallet-adapter-base@1.1.2(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bs58@6.0.0)':
+    dependencies:
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@solana/wallet-standard-chains': 1.1.0
+      '@solana/wallet-standard-features': 1.2.0
+      '@solana/wallet-standard-util': 1.1.1
+      '@solana/web3.js': 1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@wallet-standard/app': 1.0.1
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/features': 1.0.3
+      '@wallet-standard/wallet': 1.0.1
+      bs58: 6.0.0
+
   '@solana/wallet-standard-wallet-adapter-react@1.1.2(@solana/wallet-adapter-base@0.9.23(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@19.1.0)':
     dependencies:
       '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@solana/wallet-standard-wallet-adapter-base': 1.1.2(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bs58@5.0.0)
+      '@wallet-standard/app': 1.0.1
+      '@wallet-standard/base': 1.0.1
+      react: 19.1.0
+    transitivePeerDependencies:
+      - '@solana/web3.js'
+      - bs58
+
+  '@solana/wallet-standard-wallet-adapter-react@1.1.2(@solana/wallet-adapter-base@0.9.23(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@19.1.0)':
+    dependencies:
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@solana/wallet-standard-wallet-adapter-base': 1.1.2(@solana/web3.js@1.95.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bs58@6.0.0)
       '@wallet-standard/app': 1.0.1
       '@wallet-standard/base': 1.0.1
       react: 19.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,8 +226,8 @@ importers:
         version: 5.0.5(@types/react@19.1.4)(react@19.1.0)(use-sync-external-store@1.4.0(react@19.1.0))
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.0.0
-        version: 2.0.0
+        specifier: 2.2.4
+        version: 2.2.4
       '@tanstack/react-query-devtools':
         specifier: 5.29.2
         version: 5.29.2(@tanstack/react-query@5.45.1(react@19.1.0))(react@19.1.0)
@@ -1006,55 +1006,55 @@ packages:
       bs58: ^6.0.0
       viem: 2.23.11
 
-  '@biomejs/biome@2.0.0':
-    resolution: {integrity: sha512-BlUoXEOI/UQTDEj/pVfnkMo8SrZw3oOWBDrXYFT43V7HTkIUDkBRY53IC5Jx1QkZbaB+0ai1wJIfYwp9+qaJTQ==}
+  '@biomejs/biome@2.2.4':
+    resolution: {integrity: sha512-TBHU5bUy/Ok6m8c0y3pZiuO/BZoY/OcGxoLlrfQof5s8ISVwbVBdFINPQZyFfKwil8XibYWb7JMwnT8wT4WVPg==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.0.0':
-    resolution: {integrity: sha512-QvqWYtFFhhxdf8jMAdJzXW+Frc7X8XsnHQLY+TBM1fnT1TfeV/v9vsFI5L2J7GH6qN1+QEEJ19jHibCY2Ypplw==}
+  '@biomejs/cli-darwin-arm64@2.2.4':
+    resolution: {integrity: sha512-RJe2uiyaloN4hne4d2+qVj3d3gFJFbmrr5PYtkkjei1O9c+BjGXgpUPVbi8Pl8syumhzJjFsSIYkcLt2VlVLMA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.0.0':
-    resolution: {integrity: sha512-5JFhls1EfmuIH4QGFPlNpxJQFC6ic3X1ltcoLN+eSRRIPr6H/lUS1ttuD0Fj7rPgPhZqopK/jfH8UVj/1hIsQw==}
+  '@biomejs/cli-darwin-x64@2.2.4':
+    resolution: {integrity: sha512-cFsdB4ePanVWfTnPVaUX+yr8qV8ifxjBKMkZwN7gKb20qXPxd/PmwqUH8mY5wnM9+U0QwM76CxFyBRJhC9tQwg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.0.0':
-    resolution: {integrity: sha512-Bxsz8ki8+b3PytMnS5SgrGV+mbAWwIxI3ydChb/d1rURlJTMdxTTq5LTebUnlsUWAX6OvJuFeiVq9Gjn1YbCyA==}
+  '@biomejs/cli-linux-arm64-musl@2.2.4':
+    resolution: {integrity: sha512-7TNPkMQEWfjvJDaZRSkDCPT/2r5ESFPKx+TEev+I2BXDGIjfCZk2+b88FOhnJNHtksbOZv8ZWnxrA5gyTYhSsQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@2.0.0':
-    resolution: {integrity: sha512-BAH4QVi06TzAbVchXdJPsL0Z/P87jOfes15rI+p3EX9/EGTfIjaQ9lBVlHunxcmoptaA5y1Hdb9UYojIhmnjIw==}
+  '@biomejs/cli-linux-arm64@2.2.4':
+    resolution: {integrity: sha512-M/Iz48p4NAzMXOuH+tsn5BvG/Jb07KOMTdSVwJpicmhN309BeEyRyQX+n1XDF0JVSlu28+hiTQ2L4rZPvu7nMw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.0.0':
-    resolution: {integrity: sha512-tiQ0ABxMJb9I6GlfNp0ulrTiQSFacJRJO8245FFwE3ty3bfsfxlU/miblzDIi+qNrgGsLq5wIZcVYGp4c+HXZA==}
+  '@biomejs/cli-linux-x64-musl@2.2.4':
+    resolution: {integrity: sha512-m41nFDS0ksXK2gwXL6W6yZTYPMH0LughqbsxInSKetoH6morVj43szqKx79Iudkp8WRT5SxSh7qVb8KCUiewGg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@2.0.0':
-    resolution: {integrity: sha512-09PcOGYTtkopWRm6mZ/B6Mr6UHdkniUgIG/jLBv+2J8Z61ezRE+xQmpi3yNgUrFIAU4lPA9atg7mhvE/5Bo7Wg==}
+  '@biomejs/cli-linux-x64@2.2.4':
+    resolution: {integrity: sha512-orr3nnf2Dpb2ssl6aihQtvcKtLySLta4E2UcXdp7+RTa7mfJjBgIsbS0B9GC8gVu0hjOu021aU8b3/I1tn+pVQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@2.0.0':
-    resolution: {integrity: sha512-vrTtuGu91xNTEQ5ZcMJBZuDlqr32DWU1r14UfePIGndF//s2WUAmer4FmgoPgruo76rprk37e8S2A2c0psXdxw==}
+  '@biomejs/cli-win32-arm64@2.2.4':
+    resolution: {integrity: sha512-NXnfTeKHDFUWfxAefa57DiGmu9VyKi0cDqFpdI+1hJWQjGJhJutHPX0b5m+eXvTKOaf+brU+P0JrQAZMb5yYaQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.0.0':
-    resolution: {integrity: sha512-2USVQ0hklNsph/KIR72ZdeptyXNnQ3JdzPn3NbjI4Sna34CnxeiYAaZcZzXPDl5PYNFBivV4xmvT3Z3rTmyDBg==}
+  '@biomejs/cli-win32-x64@2.2.4':
+    resolution: {integrity: sha512-3Y4V4zVRarVh/B/eSHczR4LYoSVyv3Dfuvm3cWs5w/HScccS0+Wt/lHOcDTRYeHjQmMYVC3rIRWqyN2EI52+zg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -7408,39 +7408,39 @@ snapshots:
       bs58: 6.0.0
       viem: 2.23.11(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.28)
 
-  '@biomejs/biome@2.0.0':
+  '@biomejs/biome@2.2.4':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.0.0
-      '@biomejs/cli-darwin-x64': 2.0.0
-      '@biomejs/cli-linux-arm64': 2.0.0
-      '@biomejs/cli-linux-arm64-musl': 2.0.0
-      '@biomejs/cli-linux-x64': 2.0.0
-      '@biomejs/cli-linux-x64-musl': 2.0.0
-      '@biomejs/cli-win32-arm64': 2.0.0
-      '@biomejs/cli-win32-x64': 2.0.0
+      '@biomejs/cli-darwin-arm64': 2.2.4
+      '@biomejs/cli-darwin-x64': 2.2.4
+      '@biomejs/cli-linux-arm64': 2.2.4
+      '@biomejs/cli-linux-arm64-musl': 2.2.4
+      '@biomejs/cli-linux-x64': 2.2.4
+      '@biomejs/cli-linux-x64-musl': 2.2.4
+      '@biomejs/cli-win32-arm64': 2.2.4
+      '@biomejs/cli-win32-x64': 2.2.4
 
-  '@biomejs/cli-darwin-arm64@2.0.0':
+  '@biomejs/cli-darwin-arm64@2.2.4':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.0.0':
+  '@biomejs/cli-darwin-x64@2.2.4':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.0.0':
+  '@biomejs/cli-linux-arm64-musl@2.2.4':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.0.0':
+  '@biomejs/cli-linux-arm64@2.2.4':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.0.0':
+  '@biomejs/cli-linux-x64-musl@2.2.4':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.0.0':
+  '@biomejs/cli-linux-x64@2.2.4':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.0.0':
+  '@biomejs/cli-win32-arm64@2.2.4':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.0.0':
+  '@biomejs/cli-win32-x64@2.2.4':
     optional: true
 
   '@coinbase/wallet-sdk@3.9.3':

--- a/providers/state-provider/server-store.ts
+++ b/providers/state-provider/server-store.ts
@@ -40,10 +40,10 @@ const WETH = resolveTicker("WETH");
 const USDC = resolveTicker("USDC");
 
 export const initServerStore = (chainId: string | null): ServerState => {
-    if (chainId && isSupportedChainId(Number.parseInt(chainId) as ChainId)) {
+    if (chainId && isSupportedChainId(Number.parseInt(chainId, 10 /* radix */) as ChainId)) {
         return {
             ...defaultInitState,
-            chainId: Number.parseInt(chainId) as ChainId,
+            chainId: Number.parseInt(chainId, 10 /* radix */) as ChainId,
         };
     }
     return defaultInitState;


### PR DESCRIPTION
### Purpose
This PR upgrade pnpm to v10 and sets the `minimumReleaseAge` field to 1 day. This setting delays the installation of newly published versions to reduce the risk of installing compromised packages. More info [here](https://pnpm.io/settings#minimumreleaseage).