### PR TITLE
tokens: add getAllTokens and getAllBaseTokens

### DIFF
--- a/app/api/alchemy-transfers.ts
+++ b/app/api/alchemy-transfers.ts
@@ -2,7 +2,7 @@ import { getSDKConfig } from "@renegade-fi/react";
 
 import { getAlchemyRpcUrl } from "@/app/api/utils";
 
-import { DISPLAY_TOKENS } from "@/lib/token";
+import { getAllTokens } from "@/lib/token";
 
 export interface AlchemyTransfer {
     blockNum: string;
@@ -35,12 +35,10 @@ export async function getAssetTransfers({
     chainId: number;
 }): Promise<AlchemyTransfer[]> {
     const darkpool = getSDKConfig(chainId).darkpoolAddress.toLowerCase();
-    const tokenAddresses = DISPLAY_TOKENS({ chainId, hideQuoteTokens: false }).map(
-        (t) => t.address,
-    );
+    const allMints = getAllTokens(chainId).map((t) => t.address);
     const baseParams: Record<string, any> = {
         category: ["erc20"],
-        contractAddresses: tokenAddresses,
+        contractAddresses: allMints,
         excludeZeroValue: false,
         fromBlock: `0x${fromBlock.toString(16)}`,
         maxCount: "0xa",

--- a/app/api/stats/set-inflow-kv/route.ts
+++ b/app/api/stats/set-inflow-kv/route.ts
@@ -14,7 +14,7 @@ import { validateTransferLogCounts } from "@/app/api/stats/helpers";
 
 import { amountTimesPrice } from "@/hooks/use-usd-price";
 import { client } from "@/lib/clients/price-reporter";
-import { DISPLAY_TOKENS, resolveAddress } from "@/lib/token";
+import { getAllTokens, resolveAddress } from "@/lib/token";
 import { getDeployBlock } from "@/lib/viem";
 
 export const maxDuration = 300;
@@ -37,7 +37,7 @@ export async function GET(req: NextRequest) {
     try {
         // Get all token prices
         console.log("Fetching token prices");
-        const tokens = DISPLAY_TOKENS({ chainId, hideQuoteTokens: false });
+        const tokens = getAllTokens(chainId);
 
         const pricePromises = tokens.map((token) => client.getPrice(token.address));
         const priceResults = await Promise.all(pricePromises);

--- a/app/api/tokens/get-combined-balances/route.ts
+++ b/app/api/tokens/get-combined-balances/route.ts
@@ -11,15 +11,14 @@ import {
 } from "@/app/api/utils";
 
 import { env as clientEnv } from "@/env/client";
-import { ADDITIONAL_TOKENS, DISPLAY_TOKENS, ETHEREUM_TOKENS, SOLANA_TOKENS } from "@/lib/token";
+import { ADDITIONAL_TOKENS, ETHEREUM_TOKENS, getAllTokens, SOLANA_TOKENS } from "@/lib/token";
 import { solana } from "@/lib/viem";
 
 export const runtime = "edge";
 
-const tokens = DISPLAY_TOKENS({
-    chainId:
-        clientEnv.NEXT_PUBLIC_CHAIN_ENVIRONMENT === "mainnet" ? arbitrum.id : arbitrumSepolia.id,
-});
+const chainId =
+    clientEnv.NEXT_PUBLIC_CHAIN_ENVIRONMENT === "mainnet" ? arbitrum.id : arbitrumSepolia.id;
+const allTokens = getAllTokens(chainId);
 
 export async function GET(req: Request) {
     const { searchParams } = new URL(req.url);
@@ -38,7 +37,7 @@ export async function GET(req: Request) {
         await Promise.all([
             // Arbitrum token balances
             Promise.all(
-                tokens.map(async (token) => ({
+                allTokens.map(async (token) => ({
                     balance: await readErc20BalanceOf(
                         getAlchemyRpcUrl(arbitrum.id),
                         token.address,

--- a/app/assets/history-table/data-table.tsx
+++ b/app/assets/history-table/data-table.tsx
@@ -26,7 +26,7 @@ import {
 import { Toggle } from "@/components/ui/toggle";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
-import { DISPLAY_TOKENS } from "@/lib/token";
+import { getAllTokens } from "@/lib/token";
 import { useCurrentChain } from "@/providers/state-provider/hooks";
 
 interface DataTableProps<TData, TValue> {
@@ -105,7 +105,7 @@ export function DataTable<TData, TValue>({
     }, [isWithdrawal, table]);
 
     const chainId = useCurrentChain();
-    const tokens = DISPLAY_TOKENS({ chainId }).map((token) => ({
+    const tokens = getAllTokens(chainId).map((token) => ({
         label: token.ticker,
         value: token.address,
     }));

--- a/app/assets/page-client.tsx
+++ b/app/assets/page-client.tsx
@@ -17,7 +17,7 @@ import {
 import { useTaskHistory } from "@/hooks/query/use-task-history";
 import { useAssetsTableData } from "@/hooks/use-assets-table-data";
 import { ASSETS_TOOLTIP } from "@/lib/constants/tooltips";
-import { DISPLAY_TOKENS, resolveAddress } from "@/lib/token";
+import { getAllTokens, resolveAddress } from "@/lib/token";
 import { useCurrentChain } from "@/providers/state-provider/hooks";
 
 import { columns as assetColumns } from "./assets-table/columns";
@@ -37,8 +37,9 @@ export function PageClient() {
     const [showZeroRenegadeBalance, setShowZeroRenegadeBalance] = React.useState(true);
     const [showZeroOnChainBalance, setShowZeroOnChainBalance] = React.useState(true);
 
+    const allMints = getAllTokens(chainId).map((token) => token.address);
     const rawTableData = useAssetsTableData({
-        mints: DISPLAY_TOKENS({ chainId }).map((token) => token.address),
+        mints: allMints,
     });
 
     const filteredTableData = React.useMemo(() => {

--- a/app/assets/page.tsx
+++ b/app/assets/page.tsx
@@ -7,10 +7,6 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 export default async function Page() {
     const queryClient = new QueryClient();
 
-    // await Promise.all(
-    //   DISPLAY_TOKENS().map((token) => prefetchPrice(queryClient, token.address)),
-    // )
-
     return (
         <HydrationBoundary state={dehydrate(queryClient)}>
             <ScrollArea className="flex-grow" type="always">

--- a/app/components/wallet-sidebar/assets-menu-item.tsx
+++ b/app/components/wallet-sidebar/assets-menu-item.tsx
@@ -14,13 +14,14 @@ import {
 
 import { useAssetsTableData } from "@/hooks/use-assets-table-data";
 import { formatCurrency, formatCurrencyFromString } from "@/lib/format";
-import { DISPLAY_TOKENS, resolveAddress } from "@/lib/token";
+import { getAllTokens, resolveAddress } from "@/lib/token";
 import { useCurrentChain } from "@/providers/state-provider/hooks";
 
 export function AssetsMenuItem() {
     const chainId = useCurrentChain();
+    const allMints = getAllTokens(chainId).map((token) => token.address);
     const tokenData = useAssetsTableData({
-        mints: DISPLAY_TOKENS({ chainId }).map((token) => token.address),
+        mints: allMints,
     });
 
     const totalRenegadeBalanceUsd = React.useMemo(() => {

--- a/app/orders/data-table.tsx
+++ b/app/orders/data-table.tsx
@@ -33,7 +33,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 
 import { useCancelAllOrders } from "@/hooks/use-cancel-all-orders";
 import type { ExtendedOrderMetadata } from "@/hooks/use-order-table-data";
-import { DISPLAY_TOKENS } from "@/lib/token";
+import { getAllBaseTokens } from "@/lib/token";
 import { cn } from "@/lib/utils";
 import { useCurrentChain } from "@/providers/state-provider/hooks";
 
@@ -156,7 +156,7 @@ export function DataTable<TData, TValue>({
     }, [mint, table]);
 
     const chainId = useCurrentChain();
-    const tokens = DISPLAY_TOKENS({ chainId }).map((token) => ({
+    const tokens = getAllBaseTokens(chainId).map((token) => ({
         label: token.ticker,
         value: token.address,
     }));

--- a/app/stats/actions/fetch-darkpool-balances.ts
+++ b/app/stats/actions/fetch-darkpool-balances.ts
@@ -5,7 +5,7 @@ import { formatUnits } from "viem";
 import { arbitrum, base } from "viem/chains";
 import { getServerWagmiConfig } from "@/app/lib/server-wagmi-config";
 import { amountTimesPrice } from "@/hooks/use-usd-price";
-import { DISPLAY_TOKENS } from "@/lib/token";
+import { getAllTokens } from "@/lib/token";
 import { fetchAllTokenPrices, fetchChainBalances, mergeBalancesByTicker } from "./balance-helpers";
 import type { BalanceData, BalanceDataWithTotal, PricedBalance, RawBalance } from "./types";
 
@@ -22,14 +22,14 @@ export async function fetchDarkpoolBalances(): Promise<BalanceDataWithTotal> {
         const baseDarkpoolAddress = baseConfig.darkpoolAddress;
 
         // Get tokens and config for balance fetching
-        const arbitrumTokens = DISPLAY_TOKENS({ chainId: arbitrum.id, hideQuoteTokens: false });
-        const baseTokens = DISPLAY_TOKENS({ chainId: base.id, hideQuoteTokens: false });
+        const allArbitrumMints = getAllTokens(arbitrum.id);
+        const allBaseMints = getAllTokens(base.id);
         const wagmiConfig = getServerWagmiConfig();
 
         // Fetch balances first to get all mint addresses
         const [arbitrumBalances, baseBalances] = await Promise.all([
-            fetchChainBalances(arbitrum.id, arbitrumDarkpoolAddress, arbitrumTokens, wagmiConfig),
-            fetchChainBalances(base.id, baseDarkpoolAddress, baseTokens, wagmiConfig),
+            fetchChainBalances(arbitrum.id, arbitrumDarkpoolAddress, allArbitrumMints, wagmiConfig),
+            fetchChainBalances(base.id, baseDarkpoolAddress, allBaseMints, wagmiConfig),
         ]);
 
         // Collect all unique mint addresses

--- a/app/stats/charts/token-select.tsx
+++ b/app/stats/charts/token-select.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 
-import { DISPLAY_TOKENS } from "@/lib/token";
+import { getAllBaseTokens } from "@/lib/token";
 import { cn } from "@/lib/utils";
 
 type TokenSelectProps = {
@@ -26,11 +26,8 @@ export function TokenSelect({ value, onChange, chainId }: TokenSelectProps) {
     const [open, setOpen] = React.useState(false);
 
     const tokens = useMemo(() => {
-        const res = new Set<string>(
-            DISPLAY_TOKENS({
-                chainId: chainId ? chainId : undefined,
-            }).map((token) => token.ticker),
-        );
+        const allTickers = getAllBaseTokens(chainId).map((token) => token.ticker);
+        const res = new Set<string>(allTickers);
 
         return Array.from(res).map((ticker) => ({
             label: ticker,

--- a/app/trade/[base]/page.tsx
+++ b/app/trade/[base]/page.tsx
@@ -3,13 +3,13 @@ import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query
 import { redirect } from "next/navigation";
 import { PageClient } from "@/app/trade/[base]/page-client";
 import { env } from "@/env/client";
-import { DISPLAY_TOKENS } from "@/lib/token";
+import { getAllBaseTokens } from "@/lib/token";
 import { getTickerRedirect, hydrateServerState } from "./utils";
 
 export async function generateStaticParams() {
-    const tokens = DISPLAY_TOKENS();
-    return tokens.map((token) => ({
-        base: token.ticker,
+    const allTickers = getAllBaseTokens().map((token) => token.ticker);
+    return allTickers.map((ticker) => ({
+        base: ticker,
     }));
 }
 

--- a/components/dialogs/token-select-dialog.tsx
+++ b/components/dialogs/token-select-dialog.tsx
@@ -23,7 +23,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { useBackOfQueueWallet } from "@/hooks/query/use-back-of-queue-wallet";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { formatNumber } from "@/lib/format";
-import { DISPLAY_TOKENS } from "@/lib/token";
+import { getAllBaseTokens } from "@/lib/token";
 import { useClientStore } from "@/providers/state-provider/client-store-provider";
 import { useCurrentChain } from "@/providers/state-provider/hooks";
 
@@ -135,9 +135,8 @@ function TokenList({
 
     const chainId = useCurrentChain();
     const processedTokens = React.useMemo(() => {
-        return DISPLAY_TOKENS({
-            chainId,
-        })
+        const allTokens = getAllBaseTokens(chainId);
+        return allTokens
             .sort((a, b) => {
                 const balanceA = data?.get(a.address) ?? BigInt(0);
                 const balanceB = data?.get(b.address) ?? BigInt(0);

--- a/hooks/query/fees/relayer.ts
+++ b/hooks/query/fees/relayer.ts
@@ -1,7 +1,7 @@
 import { getSDKConfig } from "@renegade-fi/react";
 import type { ChainId } from "@renegade-fi/react/constants";
 import { queryOptions } from "@tanstack/react-query";
-import { DISPLAY_TOKENS } from "@/lib/token";
+import { getAllBaseTokens } from "@/lib/token";
 import { BPS_PER_DECIMAL } from "./constants";
 
 interface QueryParams {
@@ -29,13 +29,8 @@ export function relayerFeeMapQueryOptions(params: QueryParams) {
             const host = sdkCfg.relayerUrl;
             const baseUrl = `https://${host}`;
 
-            const tickersParam = Array.from(
-                new Set(
-                    DISPLAY_TOKENS({ chainId: params.chainId, hideQuoteTokens: false }).map((t) =>
-                        t.ticker.toUpperCase(),
-                    ),
-                ),
-            ).join(",");
+            const allTickers = getAllBaseTokens(params.chainId).map((t) => t.ticker.toUpperCase());
+            const tickersParam = Array.from(new Set(allTickers)).join(",");
 
             const url = `${baseUrl}/v0/order_book/relayer-fees?tickers=${tickersParam}`;
             const res = await fetch(url);

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -14,22 +14,24 @@ export type TokenInstance = InstanceType<typeof Token>;
 export const USDC_TICKER = "USDC";
 export const USDT_TICKER = "USDT";
 
-export const DISPLAY_TOKENS = (
-    options: { hideQuoteTokens?: boolean; hideTickers?: Array<string>; chainId?: number } = {},
-) => {
-    const { hideQuoteTokens = true, hideTickers = [], chainId } = options;
-    let tokens =
-        chainId && isSupportedChainId(chainId)
-            ? Token.getAllTokensOnChain(chainId)
-            : Token.getAllTokens();
-    if (hideQuoteTokens) {
-        tokens = tokens.filter((token) => token.ticker !== USDC_TICKER);
+/** Get all tokens in the remap */
+export function getAllTokens(chainId?: number): TokenInstance[] {
+    if (chainId && isSupportedChainId(chainId)) {
+        return Token.getAllTokensOnChain(chainId);
     }
-    if (hideTickers.length > 0) {
-        tokens = tokens.filter((token) => !hideTickers.includes(token.ticker));
+    return Token.getAllTokens();
+}
+
+/** Get all base tokens in the remap */
+export function getAllBaseTokens(chainId?: number): TokenInstance[] {
+    let tokens = [];
+    if (chainId && isSupportedChainId(chainId)) {
+        tokens = Token.getAllTokensOnChain(chainId);
+    } else {
+        tokens = Token.getAllTokens();
     }
-    return tokens;
-};
+    return tokens.filter((token) => token.ticker !== USDC_TICKER);
+}
 
 export const zeroAddress = "0x0000000000000000000000000000000000000000";
 const DEFAULT_TOKEN = Token.create("UNKNOWN", "UNKNOWN", zeroAddress, 18, {});


### PR DESCRIPTION
### Purpose
This PR replaces the poorly named `DISPLAY_TOKENS` method with `getAllTokens` and `getAllBaseTokens` to make it more clear what token list is being returned. This is in response to a bug where callsites were expecting all tokens but receiving token lists with USDC filtered out.