### PR TITLE
twap: add summary cards

### DIFF
--- a/app/twap/client/twap-summary-cards.tsx
+++ b/app/twap/client/twap-summary-cards.tsx
@@ -1,0 +1,71 @@
+import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface TwapSummaryCardsProps {
+    summary: {
+        cumulativeDeltaBps: number;
+        renegadeFeeBps: number;
+        binanceFeeBps: number;
+        cumulativeSold: number;
+        soldTicker: string;
+        cumulativeRenegadeReceived: number;
+        cumulativeBinanceReceived: number;
+        receivedTicker: string;
+    } | null;
+}
+
+export function TwapSummaryCards({ summary }: TwapSummaryCardsProps) {
+    if (!summary) {
+        return null;
+    }
+
+    return (
+        <div className="grid grid-cols-2 gap-6">
+            <Card>
+                <CardHeader>
+                    <CardDescription>Price Improvement</CardDescription>
+                    <CardTitle className="text-2xl font-semibold tabular-nums">
+                        {summary.cumulativeDeltaBps.toFixed(2)} bps
+                    </CardTitle>
+                </CardHeader>
+                <CardFooter className="flex-col items-start gap-1.5 text-sm">
+                    <div className="text-muted-foreground w-full flex justify-between">
+                        <span>Renegade Fee</span>
+                        <span className="tabular-nums">
+                            {`${summary.renegadeFeeBps.toFixed(1)} bps`}
+                        </span>
+                    </div>
+                    <div className="text-muted-foreground w-full flex justify-between">
+                        <span>Binance Fee</span>
+                        <span className="tabular-nums">
+                            {`${summary.binanceFeeBps.toFixed(1)} bps`}
+                        </span>
+                    </div>
+                </CardFooter>
+            </Card>
+            <Card>
+                <CardHeader>
+                    <CardDescription>Order Summary</CardDescription>
+                    <CardTitle className="text-2xl font-semibold tabular-nums slashed-zero">
+                        {`Total ${summary.soldTicker} Sold: `} {summary.cumulativeSold.toFixed(4)}
+                    </CardTitle>
+                </CardHeader>
+                <CardFooter className="flex-col items-start gap-1.5 text-sm">
+                    <div className="text-muted-foreground w-full flex justify-between">
+                        <span>
+                            {`Total ${summary.receivedTicker} bought (Binance with Renegade)`}{" "}
+                        </span>
+                        <span className="tabular-nums">
+                            {`${summary.cumulativeRenegadeReceived.toFixed(4)}`}
+                        </span>
+                    </div>
+                    <div className="text-muted-foreground w-full flex justify-between">
+                        <span>{`Total ${summary.receivedTicker} bought (Binance only)`} </span>
+                        <span className="tabular-nums">
+                            {`${summary.cumulativeBinanceReceived.toFixed(4)}`}
+                        </span>
+                    </div>
+                </CardFooter>
+            </Card>
+        </div>
+    );
+}

--- a/app/twap/page.tsx
+++ b/app/twap/page.tsx
@@ -2,6 +2,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { getSimulation } from "./actions/get-simulation";
 import { TwapParameterForm } from "./client/twap-parameter-form";
 import { TwapSimTable } from "./client/twap-sim-table";
+import { TwapSummaryCards } from "./client/twap-summary-cards";
 
 // The type of the search params
 export type SearchParams = { [key: string]: string | string[] | undefined };
@@ -9,7 +10,7 @@ type SearchParamsPromise = Promise<SearchParams>;
 
 export default async function TwapPage({ searchParams }: { searchParams: SearchParamsPromise }) {
     const params = await searchParams;
-    const { baseMint, simData, table } = await getSimulation(params);
+    const { baseMint, simData, table, summary } = await getSimulation(params);
 
     return (
         <ScrollArea className="flex-grow" type="always">
@@ -18,10 +19,13 @@ export default async function TwapPage({ searchParams }: { searchParams: SearchP
                     <h1 className="font-serif text-3xl font-bold tracking-tighter lg:tracking-normal">
                         Binance TWAP vs Binance-with-Renegade TWAP
                     </h1>
-                    <div className="flex gap-4 mt-2">
-                        <TwapSimTable table={table} />
+                    <div className="flex gap-6 mt-6">
+                        <div className="grid grid-rows-[auto_1fr] gap-6 flex-1">
+                            <TwapSummaryCards summary={summary} />
+                            <TwapSimTable table={table} />
+                        </div>
 
-                        <div className="flex-1 p-3 border">
+                        <div className="p-3 border">
                             <TwapParameterForm searchParams={params} />
                         </div>
                     </div>

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
     ({ className, ...props }, ref) => (
         <div
-            className={cn("rounded-xl border bg-card text-card-foreground shadow", className)}
+            className={cn("rounded-none border bg-card text-card-foreground shadow", className)}
             ref={ref}
             {...props}
         />


### PR DESCRIPTION
### Purpose
This PR adds the following statistics to the TWAP page:
- Total WETH sold
- total USDC bought (Binance only)
- total USDC bought (Binance with Renegade), 
- Price improvement (bps)
