### PR TITLE
ramp: set correct amount when signing permit

### DIFF
--- a/app/rampv2/core/task-context.ts
+++ b/app/rampv2/core/task-context.ts
@@ -163,4 +163,15 @@ export class TaskContext {
         const k = this.key(chainId, token);
         return (this.balances[k] ?? BigInt(0)) + (this.routeOutputs[k] ?? BigInt(0));
     }
+
+    /**
+     * Returns the correct amount for deposit/permit2 signing.
+     * If route outputs exist (swap/bridge), use expected balance (wallet + route outputs).
+     * Otherwise, use the descriptor amount (pure deposit).
+     */
+    getDepositAmount(chainId: number, token: string, descriptorAmount: bigint): bigint {
+        const key = this.key(chainId, token);
+        const hasRouteOutput = (this.routeOutputs[key] ?? BigInt(0)) > BigInt(0);
+        return hasRouteOutput ? this.getExpectedBalance(chainId, token) : descriptorAmount;
+    }
 }

--- a/app/rampv2/forms/deposit-form.tsx
+++ b/app/rampv2/forms/deposit-form.tsx
@@ -122,7 +122,6 @@ export default function DepositForm({ env, onQueueStart, initialMint }: Props) {
 
         let intent: Intent | undefined;
 
-        const token = getTokenByAddress(mint, currentChain);
         if (swapToken?.address && needsSwap) {
             intent = Intent.newSwapIntent(ctx, {
                 amount,

--- a/app/rampv2/tasks/deposit-task.ts
+++ b/app/rampv2/tasks/deposit-task.ts
@@ -76,7 +76,11 @@ export class DepositTask extends Task<DepositDescriptor, DepositState, DepositEr
 
         switch (this._state) {
             case "Pending": {
-                this._finalAmount = this.ctx.getExpectedBalance(chainId, mint);
+                this._finalAmount = this.ctx.getDepositAmount(
+                    chainId,
+                    mint,
+                    this.descriptor.amount,
+                );
 
                 await ensureCorrectChain(this.ctx, chainId);
 

--- a/app/rampv2/tasks/permit2-sig-task.ts
+++ b/app/rampv2/tasks/permit2-sig-task.ts
@@ -87,7 +87,11 @@ export class Permit2SigTask extends Task<PermitSigDescriptor, PermitSigState, Pe
                 const { chainId, mint } = this.descriptor;
                 await ensureCorrectChain(this.ctx, chainId);
 
-                const finalAmount = this.ctx.getExpectedBalance(chainId, mint);
+                const finalAmount = this.ctx.getDepositAmount(
+                    chainId,
+                    mint,
+                    this.descriptor.amount,
+                );
 
                 const sdkCfg = getSDKConfig(chainId);
                 const token = resolveAddress(mint);


### PR DESCRIPTION
### Purpose
This PR fixes a bug in the simple deposit flow of the ramp dialog wherein user inputted amounts would be overwritten by the balance cache, leading to the wrong amount being permitted and deposited.